### PR TITLE
Set max-width to 100% for images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11048,6 +11048,12 @@ a:hover {
   text-decoration: underline;
 }
 
+img {
+  vertical-align: middle;
+  border-style: none;
+  max-width: 100%;
+}
+
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
   margin-bottom: 0.5rem;

--- a/scss/bootstrap-overrides/_reboot.scss
+++ b/scss/bootstrap-overrides/_reboot.scss
@@ -51,4 +51,14 @@ a {
   }
 }
 
+// overrides _reboot.scss line 248
+//
+// Images and content
+//
+
+img {
+  vertical-align: middle;
+  border-style: none; // Remove the border on images inside links in IE 10-.
+  max-width: 100%;
+}
 


### PR DESCRIPTION
images were overflowing outside of the container so max-width was set to 100%.