### PR TITLE
Extend the image width to 100%

### DIFF
--- a/scss/illinois-framework/_paragraphs.bb.scss
+++ b/scss/illinois-framework/_paragraphs.bb.scss
@@ -35,6 +35,10 @@
         flex-wrap: wrap;
         padding: 0 0 rem(30px) 0;
       }
+
+      img {
+        width: 100%;
+      }
     }
     &__title {
 


### PR DESCRIPTION
At 350px wide the image does not fill the container of the big button box.