### PR TITLE
Moved title out of spotlight.

### DIFF
--- a/config/install/block.block.illinois_framework_theme_page_title.yml
+++ b/config/install/block.block.illinois_framework_theme_page_title.yml
@@ -1,10 +1,11 @@
+uuid: 402a200b-9dc0-440e-b693-56bf0f22ab2a
 langcode: en
 status: true
 dependencies:
-  module:
-    - system
   theme:
     - illinois_framework_theme
+_core:
+  default_config_hash: 8B2Pdj0F0sCd2v1Kv6LscyVih_zDmgi9vmK289Cm3zo
 id: illinois_framework_theme_page_title
 theme: illinois_framework_theme
 region: content
@@ -16,10 +17,4 @@ settings:
   label: 'Page title'
   provider: core
   label_display: '0'
-visibility:
-  request_path:
-    id: request_path
-    pages: '/spotlight/*'
-    negate: true
-    context_mapping: {  }
-
+visibility: {  }

--- a/templates/content/node--spotlight.html.twig
+++ b/templates/content/node--spotlight.html.twig
@@ -77,10 +77,6 @@
     <h2{{ title_attributes }}>
       <a href="{{ url }}" rel="bookmark">{{ label }}</a>
     </h2>
-  {% else %}
-  <h1{{ title_attributes.addClass(['page-title']) }}>
-    {{ label }}
-  </h1>
   {% endif %}
   {{ title_suffix }}
 
@@ -94,7 +90,7 @@
     </footer>
   {% endif %}
 
-  <div{{ content_attributes }}>
+  <div>
     {{ content }}
   </div>
 


### PR DESCRIPTION
So that we can use the page title block instead.