### PR TITLE
Move the cookie banner to the beginning of the head tag

### DIFF
--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -20,11 +20,6 @@ function illinois_framework_theme_preprocess(&$variables) {
   $variables['base_path_success'] = (array_key_exists('HTTPS', $_SERVER) ? 'https' : 'http').'://'.$_SERVER['HTTP_HOST'].'/';
   $variables['theme_path'] = $theme_path;
   $variables['files_path'] = $base_path_http . '/sites/' . $base_path . '/files/';
-  $request = \Drupal::request();
-     if ($route = $request->attributes->get(\Symfony\Cmf\Component\Routing\RouteObjectInterface::ROUTE_OBJECT)) {
-     $title = \Drupal::service('title_resolver')->getTitle($request, $route);
-     $variables['page_title'] = $title;
-  }
 
   // theme variables
   $variables['if_secondary_site_title'] = theme_get_setting('if_secondary_site_title');

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -38,6 +38,16 @@
   <head>
     <base href="{{ base_path_success ~ directory }}/" />
     <head-placeholder token="{{ placeholder_token }}">
+    {#
+      UIUC Cookie banner: needs to be placed before any other
+      script tags to function. Won't be included if running on
+      a localhost development environment.
+    #}
+    {%- set site_url = url("<current>") -%}
+    {% if 'localhost' not in site_url|render|render -%}
+      <script src="https://onetrust.techservices.illinois.edu/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="26be7d61-2017-4ea7-8a8b-8f1704889763"></script>
+      <script type="text/javascript">function OptanonWrapper() { }</script>
+    {%- endif %}
     <title>{{ head_title|safe_join(' | ') }} | UIUC</title>
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">

--- a/templates/region/region--header.html.twig
+++ b/templates/region/region--header.html.twig
@@ -64,13 +64,4 @@
     </il-nav>
   </il-header>
 </header>
-<div role="status">
-  {%- set site_url = url("<current>") -%}
-  {%- if 'localhost' not in site_url|render|render -%}
-    <!--OneTrust Cookies Consent Notice start, illinois.edu -->
-    {{ site_url|render|render }}<script src="https://onetrust.techservices.illinois.edu/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="26be7d61-2017-4ea7-8a8b-8f1704889763"></script>
-    <script type="text/javascript">function OptanonWrapper() { }</script>
-    <!--OneTrust Cookies Consent Notice end, illinois.edu -->
-  {%- endif -%}
-</div>
 {% endif %}


### PR DESCRIPTION
The UIUC cookie banner needs to be included before any other JS to function properly. Moved it out of the body tag and into the head tag.