### PR TITLE
CSS changes for icon row: altgeld text for gray background, 60px top …

### DIFF
--- a/scss/illinois-framework/_paragraphs.icon-row.scss
+++ b/scss/illinois-framework/_paragraphs.icon-row.scss
@@ -1,13 +1,15 @@
 .paragraph--type--icon-row{
-
   .field--name-field-icon-row {
     &__wrapper {
-      padding: rem(30px) 0;
+      padding-top: rem(60px) ;
     }
     &__title {
       margin-top: 0;
       margin-bottom: rem(60px);
       text-align: center;
+    }
+    &-icon_wrapper {
+      padding-bottom: rem(20px;)
     }
   }
 
@@ -16,21 +18,17 @@
     justify-content: space-evenly;
     text-align: center;
     color: var(--il-blue);
-      @include media-breakpoint-down(md) {
-        flex-wrap: wrap;
-      }
+    flex-wrap: wrap;
+    }
       @include media-breakpoint-down(sm) {
         flex-direction: column;
         align-items: center;
       }
       .field__item {
-        flex: 1 1 100%;
-        padding: 0 1rem;
+        flex: 1 1 25%;
       }
     &__wrapper{
-      @include media-breakpoint-down(md) {
-        margin: 1rem 0;
-      }
+      padding-bottom: rem(75px);
     }
   }
 
@@ -75,7 +73,7 @@
   }
   .background--color--gray{
     .field--name-field-icon-row-callout{
-      color: var(--il-blue);
+      color: var(--il-altgeld);
     }
   }
 


### PR DESCRIPTION
…padding, 75px bottom padding, added vertical spacing vetween tile and icons, more vertical spacing between items in mobile, wrapping on desktop and tablet