### PR TITLE
Displays the title on spotlight pages.

### DIFF
--- a/config/install/block.block.illinois_framework_theme_page_title.yml
+++ b/config/install/block.block.illinois_framework_theme_page_title.yml
@@ -17,9 +17,4 @@ settings:
   label: 'Page title'
   provider: core
   label_display: '0'
-visibility:
-  request_path:
-    id: request_path
-    pages: '/spotlight/*'
-    negate: true
-    context_mapping: {  }
+visibility: {  }


### PR DESCRIPTION
Removes the setting for visibility on the block for spotlights.