### PR TITLE
Removing special handling for custom block 1 from the footer

### DIFF
--- a/templates/region/region--footer.html.twig
+++ b/templates/region/region--footer.html.twig
@@ -86,13 +86,6 @@
         {% endfor %}
       </div>
     {% endif %}
-    {% if drupal_entity('block_content', 1) %}
-    <div class="il-footer-navigation">
-       <div>
-         {{ drupal_entity('block_content', 1) }}
-       </div>
-    </div>
-    {% endif %}
     <div class="il-footer-navigation">
       <div class="il-footer-navigation-column">
         {% if drupal_entity('block', 'footermenufirst') %}


### PR DESCRIPTION
Should take care of the first custom block showing up in the footer