### PR TITLE
Added col-md-12 and col-sm-12 to main title

### DIFF
--- a/templates/paragraphs/paragraph--rt.html.twig
+++ b/templates/paragraphs/paragraph--rt.html.twig
@@ -55,7 +55,7 @@
     {% block content %}
       <div class="col-lg-12 col-md-12 col-sm-12 d-flex row paragraph--type--rt__wrapper fixed-width">
         {% if content.field_rt_title['#items'] %}
-          <div class="col-lg-12 paragraph--type--rt__title">
+          <div class="col-lg-12 col-md-12 col-sm-12 paragraph--type--rt__title">
             <h2>{{ content.field_rt_title['#items'].0.value }}</h2>
           </div>
         {% endif %}


### PR DESCRIPTION
Main title when too short allows columns to flow up next to it, as it does  not specify the width at medium and small sizes. Added classes to make the main heading always fill full width. Closes #588 