### PR TITLE
Removed these padding clears, as they interfere with the flow of the …

### DIFF
--- a/scss/illinois-framework/_paragraphs.bb.scss
+++ b/scss/illinois-framework/_paragraphs.bb.scss
@@ -57,13 +57,6 @@
     }
   }
 
-
-  .col-sm-12 {
-    @include media-breakpoint-down(sm) {
-      padding: 0;
-    }
-  }
-
   &__wrapper {
 
     &.background--color {
@@ -198,17 +191,6 @@
     &.fixed-width,
     &.full-width {
       padding: 0;
-    }
-    .col-md-6:nth-child(2n) {
-      padding-right: 0;
-    }
-    .col-md-6:nth-child(2n+1) {
-      padding-left: 0;
-    }
-    .col-sm-12 {
-      @include media-breakpoint-down(md) {
-        padding: 0;
-      }
     }
   }
 }


### PR DESCRIPTION
…grid from bootstrap, causing an escape of the container. Tested on small, medium, large displays on Firefox.

Unclear why these paddings were set to zero. Looking for more information before this closes #584 or if we can go ahead and complete the fix.