### PR TITLE
Removes the offending library

### DIFF
--- a/illinois_framework_theme.info.yml
+++ b/illinois_framework_theme.info.yml
@@ -9,6 +9,9 @@ stylesheets-remove:
   - '@bootstrap4/css/style.css'
   - '@classy/css/components/details.css'
 
+libraries-override:
+  filter/caption: false
+
 # Defines libraries group in which we can add css/js.
 libraries:
   - illinois_framework_theme/global-styling


### PR DESCRIPTION
A library from Stable theme in core is adding table style to the caption, which is being broken by the toolkit css which has a different style for the caption. This fixes excludes the library from Stable from the framework theme. Closes https://github.com/web-illinois/illinois_framework_theme/issues/624