### PR TITLE
Update _block.illinois-framework-theme-breadcrumbs.scss

### DIFF
--- a/scss/illinois-framework/_block.illinois-framework-theme-breadcrumbs.scss
+++ b/scss/illinois-framework/_block.illinois-framework-theme-breadcrumbs.scss
@@ -9,6 +9,7 @@
   }
 
   ol.breadcrumb {
+    display: inline;
     line-height: 1;
 
     li.breadcrumb-item {


### PR DESCRIPTION
Add display inline so the breadcrumbs text wrap with there is a long breadcrumb name