### PR TITLE
Update Illinois Toolkit to 2.7

### DIFF
--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -21,11 +21,11 @@ web-components:
   header: true
   css:
     theme:
-      https://cdn.toolkit.illinois.edu/2.5/toolkit.css:
+      https://cdn.toolkit.illinois.edu/2.7/toolkit.css:
         type: external
         minified: true
   js:
-    https://cdn.toolkit.illinois.edu/2.5/toolkit.js:
+    https://cdn.toolkit.illinois.edu/2.7/toolkit.js:
       type: external
       minified: true
 content-adjust:


### PR DESCRIPTION
Update the toolkit to 2.7, which will include a fix for the table in an accordion issue in #696