### PR TITLE
Revert "Update Illinois Toolkit to 2.7" - go back to 2.5

### DIFF
--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -21,11 +21,11 @@ web-components:
   header: true
   css:
     theme:
-      https://cdn.toolkit.illinois.edu/2.7/toolkit.css:
+      https://cdn.toolkit.illinois.edu/2.5/toolkit.css:
         type: external
         minified: true
   js:
-    https://cdn.toolkit.illinois.edu/2.7/toolkit.js:
+    https://cdn.toolkit.illinois.edu/2.5/toolkit.js:
       type: external
       minified: true
 content-adjust:


### PR DESCRIPTION
Reverts web-illinois/illinois_framework_theme#708 - sets the version back to 2.5