### PR TITLE
Updated padding to include rich text next to side navigation

### DIFF
--- a/scss/illinois-framework/_paragraphs.rt.scss
+++ b/scss/illinois-framework/_paragraphs.rt.scss
@@ -62,6 +62,19 @@
             padding-left: 15px;
           }
         }
+        &.unset-col-lg-6:first-child {
+          @media screen and (min-width: 992px) {
+            padding-right: 15px;
+          }
+          @media screen and (max-width: 991px) {
+            padding-bottom: 15px;
+          }
+        }
+        &.unset-col-lg-6:nth-child(2) {
+          @media screen and (min-width: 992px) {
+            padding-left: 15px;
+          }
+        }
       }
     }
     &__title {


### PR DESCRIPTION
The rich text padding between 2 columns of text needed some padding between the two columns and some padding below the first column when the column breaks down to the mobile media query