### PR TITLE
Remove additional padding not needed on rich text

### DIFF
--- a/scss/illinois-framework/_paragraphs.rt.scss
+++ b/scss/illinois-framework/_paragraphs.rt.scss
@@ -100,22 +100,9 @@
   }
 }
 .il-content {
-  .background--color--gray {
-    .paragraph--type--rt__wrapper {
-      padding: rem(30px) !important;
-    }
-  }
   .background--color--white {
     .paragraph--type--rt__wrapper {
       padding: 0 !important;
-    }
-  }
-}
-
-@include media-breakpoint-down(md) {
-  .il-content {
-    .paragraph--type--rt__wrapper {
-      padding-left: 0 !important;
     }
   }
 }

--- a/scss/illinois-framework/_paragraphs.scss
+++ b/scss/illinois-framework/_paragraphs.scss
@@ -28,7 +28,7 @@
 }
 //select the last paragraph and remove the bottom padding
 .il-content {
-  div[id^="paragraph--"]:last-child {
+  div[id^="paragraph--"]:last-child:has(.background--color--white) {
     padding-bottom: 0 !important;
   }
 }


### PR DESCRIPTION
Previously we added standard padding to all paragraphs, now we are removing any non-standard padding that is left over.  Adjusted the last paragraph to remove the bottom padding if the last paragraph has a white background.