### PR TITLE
Update _paragraphs.feature--split.scss

### DIFF
--- a/scss/illinois-framework/_paragraphs.feature--split.scss
+++ b/scss/illinois-framework/_paragraphs.feature--split.scss
@@ -54,7 +54,6 @@
     &__body {
       p,
       li {
-        color: white;
         line-height: 2.125rem;
         font-size: rem(24px);
       }


### PR DESCRIPTION
Removed white color specified for all split feature backgrounds