### PR TITLE
Fix error from blank body field in big button paragraph

### DIFF
--- a/illinois_framework_theme.info.yml
+++ b/illinois_framework_theme.info.yml
@@ -4,7 +4,7 @@ description: 'The Illinois Framework Theme'
 core: 8.x
 core_version_requirement: ^8 || ^9
 base theme: bootstrap4
-version: '2.3'
+version: '2.4'
 
 stylesheets-remove:
   - '@bootstrap4/css/style.css'

--- a/templates/paragraphs/paragraph--bb.html.twig
+++ b/templates/paragraphs/paragraph--bb.html.twig
@@ -83,9 +83,11 @@
                   <div class="field--name-field-bb-content__title title">
                     <h2 class="field__item">{{ title }}</h2>
                   </div>
+                  {% if body|render|trim is not empty %}
                   <div class="field--name-field-bb-content__body body">
                     <div class="field__item">{{ body|striptags }}</div>
                   </div>
+                  {% endif %}
                 </div>
               </div>
               </a>


### PR DESCRIPTION
Closes issue: Big button paragraph throws error when body is left blank #859
