### PR TITLE
Update _paragraphs.list.scss

### DIFF
--- a/scss/illinois-framework/_paragraphs.list.scss
+++ b/scss/illinois-framework/_paragraphs.list.scss
@@ -66,6 +66,10 @@
       }
       p a {
         line-break: anywhere;
+
+        &.il-button {
+          line-break: auto;
+        }
       }
     }
   }


### PR DESCRIPTION
Links with the button class were breaking in the middle of the word (anywhere) when they had long words in them.  Set the break to auto for the il-button class within a paragraph to override the line-break anywhere setting.