### PR TITLE
Update region--header.html.twig

### DIFF
--- a/templates/region/region--header.html.twig
+++ b/templates/region/region--header.html.twig
@@ -49,7 +49,7 @@
           {% set link = if_header_links[loop.index0][1] %}
           {% set text = if_header_links[loop.index0][0] %}
           {% if link != NULL and text != NULL %}
-            <li><a id="link-{{ loop.index1 }}" href="{{ link }}">{{ text }}</a></li>
+            <li><a id="il-link--{{ loop.index }}" href="{{ link }}">{{ text }}</a></li>
           {% endif %}
         {% endfor %}
       </ul>


### PR DESCRIPTION
Replaced the broke ID which started on loop.index1 (which doesn't exist in twig) to loop.index and altered the ID name to align with the component class name.