### PR TITLE
Add unpublished class to main tag to fix issue #957

### DIFF
--- a/scss/illinois-framework/_region.content.scss
+++ b/scss/illinois-framework/_region.content.scss
@@ -9,8 +9,9 @@
 
 
 /* Show message on content that is unpublished */
-article.is-unpublished:before {
-  content: "This page is not published and will not be visible to unauthenticated users";
+article.is-unpublished:before,
+main.is-unpublished:before {
+  content: "This page is unpublished and is only visible to site editors";
   text-align: center;
   padding: 2em;
   margin-bottom: 2em;

--- a/templates/layout/page--content-page.html.twig
+++ b/templates/layout/page--content-page.html.twig
@@ -75,6 +75,10 @@
   {# if a side navigation exists and /'latest' is not in the url then spoof the content region #}
   {% if node.field_sidebar.0.value == "sidebar" and '/latest' not in url|render|render %}
 
+  {# Add an is-unpublished class to main tag if the node is unpublished #}
+  {% set unpublished = [not node.isPublished() ? 'is-unpublished'] %}
+  {% set mainClasses = mainClasses|merge(unpublished) %}
+
   <a name="main-content" aria-label="Start of content region"></a>
   <main{{ attributes.addClass(mainClasses) }} role="main">
   <div class="il-content-with-section-nav section-nav-example">


### PR DESCRIPTION
Adds a 'is-unpublished' class to the main tag on content pages so that the CSS warning will display on unpublished pages.