### PR TITLE
Fix for SCSS compiling issue #967

### DIFF
--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -3,7 +3,7 @@ global-styling:
     theme:
       fonts/font-awesome-4.7.0/css/font-awesome.css: {}
       fonts/font-awesome-4.7.0/css/illinois-icons.css: {}
-      scss/style.scss: { css_path: '/css/' }
+      scss/style.scss: { }
   js:
     https://emergency.publicaffairs.illinois.edu/illinois.js:
       type: external


### PR DESCRIPTION
Fixes issue #967

From the module page (https://www.drupal.org/project/scss_compiler):

"By default, compiled files save to public://scss_compiler"