### PR TITLE
removing 0 padding on field item so youtube video will display

### DIFF
--- a/scss/illinois-framework/_field--name-body.scss
+++ b/scss/illinois-framework/_field--name-body.scss
@@ -1,10 +1,6 @@
 .content {
   .field--name-body {
     padding: 0 25px 75px 50px !important;
-
-    .field__item {
-      padding: 0 !important;
-    }
   }
 }
 .il-content {
@@ -13,7 +9,6 @@
 
     .field__item {
       margin: 0.25rem 0;
-      padding: 0 !important;
     }
   }
 }


### PR DESCRIPTION
removed padding: 0 on field item since it was causing youtube added through media to not display