### PR TITLE
Fix for issue #1063 - Login footer button shoud link to shib login

### DIFF
--- a/config/install/illinois_framework_theme.settings.yml
+++ b/config/install/illinois_framework_theme.settings.yml
@@ -53,3 +53,4 @@ if_subfooter_text_4: ''
 if_subfooter_link_4: ''
 if_subfooter_text_5: ''
 if_subfooter_link_5: ''
+if_shibboleth_login_direct: true

--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -9,7 +9,37 @@ use Drupal\paragraphs\ParagraphInterface;
  */
 function illinois_framework_theme_preprocess(&$variables) {
 
-  // path variables
+  // Get the current user service.
+  $current_user = \Drupal::currentUser();
+
+  // Check if the user is authenticated to dynamically set the login/logout link.
+  if ($current_user->isAuthenticated()) {
+    // --- USER IS LOGGED IN ---
+    // Set the link text to "Logout".
+    $variables['login_logout_text'] = t('Logout');
+
+    $variables['login_logout_url'] = Url::fromRoute('user.logout');
+  }
+  else {
+    // --- USER IS LOGGED OUT ---
+    // Set the link text to "Login".
+    $variables['login_logout_text'] = t('Login');
+
+    // Get the current page path to use as the destination parameter for the redirect.
+    $destination = \Drupal::service('redirect.destination')->getAsArray();
+
+    // Check if simplesamlphp_auth is enabled for login.
+    if (\Drupal::moduleHandler()->moduleExists('simplesamlphp_auth')) {
+      // The module is enabled, so point to the Shibboleth login with the destination.
+      $login_url = Url::fromRoute('simplesamlphp_auth.saml_login', [], ['query' => $destination]);
+    }
+    else {
+      // The module is not enabled, so use the standard Drupal login with the destination.
+      $login_url = Url::fromRoute('user.login', [], ['query' => $destination]);
+    }
+    $variables['login_logout_url'] = $login_url;
+  }
+
   // TODO: condense these into a single array like ['path_vars']['var']
   $current_path = \Drupal::service('path.current')->getPath();
   $canoncial_url = Url::fromRoute('<current>', [], ['absolute' => 'true'])->toString();

--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -17,7 +17,6 @@ function illinois_framework_theme_preprocess(&$variables) {
     // --- USER IS LOGGED IN ---
     // Set the link text to "Logout".
     $variables['login_logout_text'] = t('Logout');
-
     $variables['login_logout_url'] = Url::fromRoute('user.logout');
   }
   else {
@@ -28,9 +27,21 @@ function illinois_framework_theme_preprocess(&$variables) {
     // Get the current page path to use as the destination parameter for the redirect.
     $destination = \Drupal::service('redirect.destination')->getAsArray();
 
-    // Check if simplesamlphp_auth is enabled for login.
+    // Get the theme setting for direct Shibboleth login.
+    $shibboleth_direct_login = theme_get_setting('if_shibboleth_login_direct');
+
+    // Default SAML status to inactive.
+    $saml_is_active = FALSE;
+    // First, check if the simplesamlphp_auth module exists before trying to access its configuration.
     if (\Drupal::moduleHandler()->moduleExists('simplesamlphp_auth')) {
-      // The module is enabled, so point to the Shibboleth login with the destination.
+      // If it exists, get the configuration and check if it's active.
+      $saml_config = \Drupal::config('simplesamlphp_auth.settings');
+      $saml_is_active = $saml_config->get('activate');
+    }
+
+    // Check if the theme setting is enabled and the SAML module is active for authentication.
+    if ($shibboleth_direct_login && $saml_is_active) {
+      // The module is enabled and active, so point to the Shibboleth login with the destination.
       $login_url = Url::fromRoute('simplesamlphp_auth.saml_login', [], ['query' => $destination]);
     }
     else {

--- a/templates/region/region--footer.html.twig
+++ b/templates/region/region--footer.html.twig
@@ -101,7 +101,7 @@
         <a href="{{ link }}">{{ text }}</a>
       {% endif %}
     {% endfor %}
-    <a href="/user">Login</a>
+    <a href="{{ login_logout_url }}" rel="nofollow">{{ login_logout_text }}</a>
   </div>
   <div class="footer-menus">
     <div>

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -105,6 +105,12 @@ function illinois_framework_theme_form_system_theme_settings_alter(&$form, FormS
       '#title' => t('Footer Example'),
       '#weight' => -93,
   );
+  $form['if_footer']['if_shibboleth_login_direct'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Link Login button directly to the Shibboleth login (if enabled)'),
+    '#description' => "Select this to have the login button link directly to the Shibboleth login page.",
+    '#default_value' => theme_get_setting('if_shibboleth_login_direct'),
+  );
   // Select Social Media to display in the footer
   $form['if_footer']['if_footer_social'] = array(
     '#type' => 'fieldset',


### PR DESCRIPTION
Fix for issue #1063. 

- Adds a theme setting that will link the footer login button directly to the /saml_login path instead of the Drupal internal login page. 
- Also adds a ?destination parameter that will take the user back to the page they were on when pressing the login button.
- The button changes to "Logout" when a user is logged in 