### PR TITLE
Revert CSS changes for custom content type

### DIFF
--- a/scss/illinois-framework/_regions.scss
+++ b/scss/illinois-framework/_regions.scss
@@ -26,12 +26,3 @@
     padding: rem(10px) var(--il-content-margin);
   }
 }
-
-//adds formatting to custom content types
-.custom-content-page {
-  article {
-  .field--name-body {
-     padding: 0 !important;
-  }
-  }
-}


### PR DESCRIPTION
The CSS changes caused the custom content type page to show the full-width of the browser instead of being constrained to the normal margins. We'll keep the added class in case we need to apply CSS to custom content types.