### PR TITLE
4.x Add check to see if social footer is not empty, then render it

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## 📝 Description
+*Provide a short summary that describes how the fix is implemented*
+
+Fixes # (issue number)
+
+---
+
+## ✅ Peer Review Checklist
+*Reviewers: Please verify the following before approving.*
+
+- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
+- There is a **short summary** that describes _how_ the fix is implemented
+- **Verifying work**: Verify that the changes made are addressing the linked issue
+- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
+- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
+- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
+- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
+- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
+- **Comments:** Complex logic is explained inline.
+- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)
+
+---
+
+## 📸 Screenshots / Video (Optional)
+*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*

--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -85,19 +85,30 @@ function illinois_framework_theme_preprocess(&$variables) {
   $variables['if_footer']['if_footer_address']['if_footer_address_zip'] = theme_get_setting('if_footer_address_zip');
   $variables['if_footer']['if_footer_address']['if_footer_address_tel'] = theme_get_setting('if_footer_address_tel');
   $variables['if_footer']['if_footer_address']['if_footer_address_email'] = theme_get_setting('if_footer_address_email');
-  $variables['if_footer']['if_footer_social']['if_footer_social_facebook'] = theme_get_setting('if_footer_social_facebook');
-  $variables['if_footer']['if_footer_social']['if_footer_social_twitter'] = theme_get_setting('if_footer_social_twitter');
-  $variables['if_footer']['if_footer_social']['if_footer_social_instagram'] = theme_get_setting('if_footer_social_instagram');
-  $variables['if_footer']['if_footer_social']['if_footer_social_youtube'] = theme_get_setting('if_footer_social_youtube');
-  $variables['if_footer']['if_footer_social']['if_footer_social_linkedin'] = theme_get_setting('if_footer_social_linkedin');
-  $variables['if_footer']['if_footer_social']['if_footer_social_bluesky'] = theme_get_setting('if_footer_social_bluesky');
-  $variables['if_footer']['if_footer_social']['if_footer_social_calendar'] = theme_get_setting('if_footer_social_calendar');
-  $variables['if_footer']['if_footer_social']['if_footer_social_tiktok'] = theme_get_setting('if_footer_social_tiktok');
-  $variables['if_footer']['if_footer_social']['if_footer_social_threads'] = theme_get_setting('if_footer_social_threads');
-  $variables['if_footer']['if_footer_social']['if_footer_social_pinterest'] = theme_get_setting('if_footer_social_pinterest');
-  $variables['if_footer']['if_footer_social']['if_footer_social_snapchat'] = theme_get_setting('if_footer_social_snapchat');
-  $variables['if_footer']['if_footer_social']['if_footer_social_weibo'] = theme_get_setting('if_footer_social_weibo');
-  $variables['if_footer']['if_footer_social']['if_footer_social_whatsapp'] = theme_get_setting('if_footer_social_whatsapp');
+
+  // Set the social media links into a variable so we can use array_filter to exclude empty items
+  $if_footer_social = [
+
+    // Use the lowercase name of the social media supported by the framework.
+    'if_footer_social_instagram' => theme_get_setting('if_footer_social_instagram'),
+    'if_footer_social_facebook' => theme_get_setting('if_footer_social_facebook'),
+    'if_footer_social_twitter' => theme_get_setting('if_footer_social_twitter'),
+    'if_footer_social_youtube' => theme_get_setting('if_footer_social_youtube'),
+    'if_footer_social_linkedin' => theme_get_setting('if_footer_social_linkedin'),
+    'if_footer_social_bluesky' => theme_get_setting('if_footer_social_bluesky'),
+    'if_footer_social_calendar' => theme_get_setting('if_footer_social_calendar'),
+    'if_footer_social_tiktok' => theme_get_setting('if_footer_social_tiktok'),
+    'if_footer_social_pinterest' => theme_get_setting('if_footer_social_pinterest'),
+    'if_footer_social_snapchat' => theme_get_setting('if_footer_social_snapchat'),
+    'if_footer_social_weibo' => theme_get_setting('if_footer_social_weibo'),
+    'if_footer_social_whatsapp' => theme_get_setting('if_footer_social_whatsapp'),
+    'if_footer_social_threads' => theme_get_setting('if_footer_social_threads'),
+    
+  ];
+
+  // Remove empty elements and set them to the right variable
+  $variables['if_footer']['if_footer_social'] = array_filter($if_footer_social);
+
   $variables['if_footer_colleges'][0][0] = theme_get_setting('if_footer_college_text_1');
   $variables['if_footer_colleges'][0][1] = theme_get_setting('if_footer_college_link_1');
   $variables['if_footer_colleges'][1][0] = theme_get_setting('if_footer_college_text_2');

--- a/templates/region/region--footer.html.twig
+++ b/templates/region/region--footer.html.twig
@@ -30,6 +30,7 @@
     {% endif %}
   {% endif %}
   <a slot="site-name" href="/">{{ drupal_config('system.site', 'name') | raw }}</a>
+ {% if if_footer['if_footer_social'] %}
   <nav slot="social" aria-label="Social media">
     <ul>
       {% if if_footer['if_footer_social']['if_footer_social_instagram'] %}
@@ -73,6 +74,7 @@
       {% endif %}
     </ul>
   </nav>
+  {% endif %}
   <address slot="address">
     <p>
       {% if if_footer['if_footer_address']['if_footer_address_street_one'] %}


### PR DESCRIPTION
Addresses #1110.

### How this addresses the issue

Basically, this updates the social media placement to have an if wrapper in the region, where we look to see if the social media variable (if_footer['if_footer_social']) is passed at all. If any social media is set in the theme, then the variable is present, and we can safely render the wrapper.

### Testing Steps

1. Copy down a site with social media in the footer.
2. Verify the social media renders in the footer on local with this change present.
3. Remove the social media links from the Illinois Framework theme settings, so that no social media is present.
4. Verify the social media region is no longer present in the footer, and it does not have an empty block.
