### PR TITLE
5.x: Empty ul social footer

### DIFF
--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -96,7 +96,8 @@ function illinois_framework_theme_preprocess(&$variables) {
     // Use the lowercase name of the social media supported by the framework.
     'instagram' => theme_get_setting('if_footer_social_instagram'),
     'facebook' => theme_get_setting('if_footer_social_facebook'),
-    'twitter' => theme_get_setting('if_footer_social_twitter'),
+    // add an override for the setting to adjust for renaming twitter to x.
+    'x' => theme_get_setting('if_footer_social_twitter'),
     'youtube' => theme_get_setting('if_footer_social_youtube'),
     'linkedin' => theme_get_setting('if_footer_social_linkedin'),
     'bluesky' => theme_get_setting('if_footer_social_bluesky'),

--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -89,19 +89,30 @@ function illinois_framework_theme_preprocess(&$variables) {
   $variables['if_footer']['if_footer_address']['if_footer_address_zip'] = theme_get_setting('if_footer_address_zip');
   $variables['if_footer']['if_footer_address']['if_footer_address_tel'] = theme_get_setting('if_footer_address_tel');
   $variables['if_footer']['if_footer_address']['if_footer_address_email'] = theme_get_setting('if_footer_address_email');
-  $variables['if_footer']['if_footer_social']['if_footer_social_facebook'] = theme_get_setting('if_footer_social_facebook');
-  $variables['if_footer']['if_footer_social']['if_footer_social_twitter'] = theme_get_setting('if_footer_social_twitter');
-  $variables['if_footer']['if_footer_social']['if_footer_social_instagram'] = theme_get_setting('if_footer_social_instagram');
-  $variables['if_footer']['if_footer_social']['if_footer_social_youtube'] = theme_get_setting('if_footer_social_youtube');
-  $variables['if_footer']['if_footer_social']['if_footer_social_linkedin'] = theme_get_setting('if_footer_social_linkedin');
-  $variables['if_footer']['if_footer_social']['if_footer_social_bluesky'] = theme_get_setting('if_footer_social_bluesky');
-  $variables['if_footer']['if_footer_social']['if_footer_social_calendar'] = theme_get_setting('if_footer_social_calendar');
-  $variables['if_footer']['if_footer_social']['if_footer_social_tiktok'] = theme_get_setting('if_footer_social_tiktok');
-  $variables['if_footer']['if_footer_social']['if_footer_social_threads'] = theme_get_setting('if_footer_social_threads');
-  $variables['if_footer']['if_footer_social']['if_footer_social_pinterest'] = theme_get_setting('if_footer_social_pinterest');
-  $variables['if_footer']['if_footer_social']['if_footer_social_snapchat'] = theme_get_setting('if_footer_social_snapchat');
-  $variables['if_footer']['if_footer_social']['if_footer_social_weibo'] = theme_get_setting('if_footer_social_weibo');
-  $variables['if_footer']['if_footer_social']['if_footer_social_whatsapp'] = theme_get_setting('if_footer_social_whatsapp');
+
+  // Set the social media links into a variable so we can use array_filter to exclude empty items
+  $if_footer_social = [
+
+    // Use the lowercase name of the social media supported by the framework.
+    'instagram' => theme_get_setting('if_footer_social_instagram'),
+    'facebook' => theme_get_setting('if_footer_social_facebook'),
+    'twitter' => theme_get_setting('if_footer_social_twitter'),
+    'youtube' => theme_get_setting('if_footer_social_youtube'),
+    'linkedin' => theme_get_setting('if_footer_social_linkedin'),
+    'bluesky' => theme_get_setting('if_footer_social_bluesky'),
+    'calendar' => theme_get_setting('if_footer_social_calendar'),
+    'tiktok' => theme_get_setting('if_footer_social_tiktok'),
+    'pinterest' => theme_get_setting('if_footer_social_pinterest'),
+    'snapchat' => theme_get_setting('if_footer_social_snapchat'),
+    'weibo' => theme_get_setting('if_footer_social_weibo'),
+    'whatsapp' => theme_get_setting('if_footer_social_whatsapp'),
+    'threads' => theme_get_setting('if_footer_social_threads'),
+    
+  ];
+
+  // Remove empty elements and set them to the right variable
+  $variables['if_footer']['if_footer_social'] = array_filter($if_footer_social);
+
   $variables['if_footer_colleges'][0][0] = theme_get_setting('if_footer_college_text_1');
   $variables['if_footer_colleges'][0][1] = theme_get_setting('if_footer_college_link_1');
   $variables['if_footer_colleges'][1][0] = theme_get_setting('if_footer_college_text_2');

--- a/templates/region/region--footer.html.twig
+++ b/templates/region/region--footer.html.twig
@@ -23,45 +23,9 @@
 {% if if_footer['if_footer_social'] %}
 <nav slot="social" aria-label="Social media">
   <ul>
-    {% if if_footer['if_footer_social']['if_footer_social_instagram'] %}
-      <li><a data-service="instagram" href="{{ if_footer['if_footer_social']['if_footer_social_instagram'] }}">Instagram</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_facebook'] %}
-      <li><a data-service="facebook" href="{{ if_footer['if_footer_social']['if_footer_social_facebook'] }}">Facebook</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_twitter'] %}
-      <li><a data-service="x" href="{{ if_footer['if_footer_social']['if_footer_social_twitter'] }}">x</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_youtube'] %}
-      <li><a data-service="youtube" href="{{ if_footer['if_footer_social']['if_footer_social_youtube'] }}">YouTube</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_linkedin'] %}
-      <li><a data-service="linkedin" href="{{ if_footer['if_footer_social']['if_footer_social_linkedin'] }}">LinkedIn</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_bluesky'] %}
-      <li><a data-service="bluesky" href="{{ if_footer['if_footer_social']['if_footer_social_bluesky'] }}">Bluesky</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_calendar'] %}
-      <li><a data-service="calendar" href="{{ if_footer['if_footer_social']['if_footer_social_calendar'] }}">Calendar</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_tiktok'] %}
-      <li><a data-service="tiktok" href="{{ if_footer['if_footer_social']['if_footer_social_tiktok'] }}">TikTok</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_pinterest'] %}
-      <li><a data-service="pinterest" href="{{ if_footer['if_footer_social']['if_footer_social_pinterest'] }}">Pinterest</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_snapchat'] %}
-      <li><a data-service="snapchat" href="{{ if_footer['if_footer_social']['if_footer_social_snapchat'] }}">Snapchat</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_weibo'] %}
-      <li><a data-service="weibo" href="{{ if_footer['if_footer_social']['if_footer_social_weibo'] }}">Weibo</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_whatsapp'] %}
-      <li><a data-service="whatsapp" href="{{ if_footer['if_footer_social']['if_footer_social_whatsapp'] }}">WhatsApp</a></li>
-    {% endif %}
-    {% if if_footer['if_footer_social']['if_footer_social_threads'] %}
-      <li><a data-service="threads" href="{{ if_footer['if_footer_social']['if_footer_social_threads'] }}">Threads</a></li>
-    {% endif %}
+  {% for socialname, sociallink in if_footer['if_footer_social'] %}
+    <li><a data-service="{{ socialname }}" href="{{ sociallink }}">{{ socialname|capitalize }}</a></li>
+  {% endfor %}
   </ul>
 </nav>
 {% endif %}

--- a/templates/region/region--footer.html.twig
+++ b/templates/region/region--footer.html.twig
@@ -20,6 +20,7 @@
   {% endif %}
 {% endif %}
 <a slot="site-name" href="/">{{ drupal_config('system.site', 'name') | raw }}</a>
+{% if if_footer['if_footer_social'] %}
 <nav slot="social" aria-label="Social media">
   <ul>
     {% if if_footer['if_footer_social']['if_footer_social_instagram'] %}
@@ -63,6 +64,7 @@
     {% endif %}
   </ul>
 </nav>
+{% endif %}
 <address slot="address">
   <p>
     {% if if_footer['if_footer_address']['if_footer_address_street_one'] %}


### PR DESCRIPTION
Addresses #1110  for 5.x. Created to work around merge conflicts introduced by 5.x changes. See also #1111 for the 4.x version and testing steps.