### PR TITLE
Modify hoverbox to allow keyboard tabbing, and remove surplus hidden …

### DIFF
--- a/scss/illinois-framework/_node.news.scss
+++ b/scss/illinois-framework/_node.news.scss
@@ -470,8 +470,10 @@ article.news {
           -ms-transform: translateY(65%);
           transform: translateY(65%);
         }
+        &:focus-within,
         &:hover,
-        &.active {
+        &:active
+        {
           .hvrbox-layer_slideup {
           -moz-transform: translateY(0);
           -webkit-transform: translateY(0);

--- a/templates/node/node--news--hvrbox-card.html.twig
+++ b/templates/node/node--news--hvrbox-card.html.twig
@@ -65,16 +65,13 @@
  *
  * @see template_preprocess_node()
  *
- * @todo Remove the id attribute (or make it a class), because if that gets
- *   rendered twice on a page this is invalid CSS for example: two lists
- *   in different view modes.
  */
 #}
 
 <div class="hvrbox">
 	{{content.field_if_meda_featured_image|raw}}
 	<div class="hvrbox-layer_top hvrbox-layer_slideup">
-        <a href="{{ url }}"></a>
+        <a href="{{ url }}" aria-label="{{ label|render|striptags|trim }}"></a>
         <div class="hvrbox-text">
             <div class="hvrbox-title">{{ label }}</div>
             <div class="hvrbox-body">{{ content.body }}</div>

--- a/templates/node/node--news--hvrbox-card.html.twig
+++ b/templates/node/node--news--hvrbox-card.html.twig
@@ -74,11 +74,9 @@
 <div class="hvrbox">
 	{{content.field_if_meda_featured_image|raw}}
 	<div class="hvrbox-layer_top hvrbox-layer_slideup">
-        <a href="{{ url }}" ><span class="visually-hidden">Read article: {{ label }} </span></a>
-		<div class="hvrbox-text">
-      <div class="hvrbox-title">{{ label }} </div>
-      <div class="hvrbox-body">{{ content.body }}</div>
-    </div>
-{#    <a href="{{ url }}" class="more-link"><span class="visually-hidden">Read article: {{ label }} </span></a>#}
+        <div class="hvrbox-text">
+            <div class="hvrbox-title"><a href="{{ url }}" >{{ label }}</a></div>
+            <div class="hvrbox-body">{{ content.body }}</div>
+        </div>
 	</div>
 </div>

--- a/templates/node/node--news--hvrbox-card.html.twig
+++ b/templates/node/node--news--hvrbox-card.html.twig
@@ -74,9 +74,11 @@
 <div class="hvrbox">
 	{{content.field_if_meda_featured_image|raw}}
 	<div class="hvrbox-layer_top hvrbox-layer_slideup">
+        <a href="{{ url }}"></a>
         <div class="hvrbox-text">
-            <div class="hvrbox-title"><a href="{{ url }}" >{{ label }}</a></div>
+            <div class="hvrbox-title">{{ label }}</div>
             <div class="hvrbox-body">{{ content.body }}</div>
         </div>
+        
 	</div>
 </div>


### PR DESCRIPTION
…link that is lending to confusing tabbing.

### How this addresses the issue

The current hoverbox responds oddly to keyboard tabbing. The expectation seems to be that the user will hover the main container. This does not work for keyboard tabbing, as the there is no tab element that matches the css properties. This pr updates the css to instead target focus-within, a newer css property with widespread support, that allows for any subelement in the hoverbox container to trigger the show the box css. This does not directly address the keyboard tabbing. Instead, the way the link to the news story is rendered is updated instead, so that now the title is properly a link, and a second hidden title is removed to reduce keyboard tabbing confusion. This allows tabbing to a sub-element, and triggering of the show the text css.

### Testing steps

1. Create a page with a hoverbox news display on it
2. Tab through page into hoverbox
3. Hoverbox should open when tabbed into