### PR TITLE
added valid_header_links check and a loop to display if valid

### DIFF
--- a/templates/region/region--header.html.twig
+++ b/templates/region/region--header.html.twig
@@ -38,17 +38,26 @@
     <input type="search" name="keys" aria-labelledby="search-button">
     <button id="search-button" type="submit">Search</button>
   </form>
-  <nav slot="links" aria-label="Utility">
-    <ul>
-      {% for header_link in if_header_links %}
-        {% set link = if_header_links[loop.index0][1] %}
-        {% set text = if_header_links[loop.index0][0] %}
-        {% if link != NULL and text != NULL %}
-          <li><a id="il-link--{{ loop.index }}" href="{{ link }}">{{ text }}</a></li>
-        {% endif %}
-      {% endfor %}
-    </ul>
-  </nav>
+  {% set valid_header_links = [] %}
+
+  {% for header_link in if_header_links %}
+    {% if header_link[0] is not empty and header_link[1] is not empty %}
+      {% set valid_header_links = valid_header_links|merge([header_link]) %}
+    {% endif %}
+  {% endfor %}
+  {% if valid_header_links|length > 0 %}
+    <nav slot="links" aria-label="Utility">
+      <ul>
+        {% for header_link in valid_header_links %}
+          <li>
+            <a id="il-link--{{ loop.index }}" href="{{ header_link[1] }}">
+              {{ header_link[0] }}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </nav>
+  {% endif %}
   <ilw-header-menu slot="navigation">
     {% if menu_type == 'mega' %}
       {{ drupal_entity('block', 'mainnavigation', check_access=false) }}


### PR DESCRIPTION
## 📝 Description
*Provide a short summary that describes how the fix is implemented*

Fixes # (issue number)

Fixes 1086, [Empty ULs in the Header](https://github.com/web-illinois/illinois_framework_theme/issues/1086). If header_links are not empty, merge the links, set the links, and loop through and iterate on each of the links to display in the header with the nav slot labeled "Utility". If the links are empty, it does not display. 

Previously, the nav slot displayed without any conditional logic.

Please verify this works accordingly
---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
