### PR TITLE
Removed H2 section completely, aria-label should be enough to alert u…

### DIFF
--- a/templates/navigation/breadcrumb.html.twig
+++ b/templates/navigation/breadcrumb.html.twig
@@ -9,7 +9,6 @@
 #}
 {% if breadcrumb %}
   <nav aria-label="breadcrumb">
-    <h2 id="system-breadcrumb" class="visually-hidden">{{ 'Breadcrumb'|t }}</h2>
     <ol class="breadcrumb">
     {% for item in breadcrumb %}
       <li class="breadcrumb-item">


### PR DESCRIPTION
…sers of the breadcrumb navigation.

## 📝 Description
Removed H2 line completely. Per Tim O. aria=label="breadcrumb" is enough to alert screen reader of breadcrumb nav. 

Fixes # 1081

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
