### PR TITLE
horizontal scrollbar shows when full width components/paragraphs used

### DIFF
--- a/css/base/reset.css
+++ b/css/base/reset.css
@@ -11,6 +11,14 @@ body {
 ilw-columns {
   overflow: hidden;
 }
+/* fix for toolkit components that overflow and cause horizontal scrollbar*/
+.layout-overflow {
+  overflow-x: clip;
+}
+/* fallback */
+@supports not (overflow: clip) {
+  .layout-overflow { overflow-x: hidden; }
+}
 a {
   color: var(--ilw-link--color);
   text-decoration: underline;

--- a/templates/paragraphs/paragraph--bb.html.twig
+++ b/templates/paragraphs/paragraph--bb.html.twig
@@ -52,7 +52,8 @@
   'paragraph',
   'paragraph--type--' ~ paragraph_bundle,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ? 'paragraph--unpublished'
+  not paragraph.isPublished() ? 'paragraph--unpublished',
+  'layout-overflow'
 ]
 %}
 {{ attach_library('illinois_framework_theme/paragraph-bb') }}

--- a/templates/paragraphs/paragraph--calendar.html.twig
+++ b/templates/paragraphs/paragraph--calendar.html.twig
@@ -43,7 +43,8 @@
   'paragraph',
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ? 'paragraph--unpublished'
+  not paragraph.isPublished() ? 'paragraph--unpublished',
+  'layout-overflow'
 ]
 %}
 {{ attach_library('illinois_framework_theme/paragraph-calendar') }}

--- a/templates/paragraphs/paragraph--icon-row.html.twig
+++ b/templates/paragraphs/paragraph--icon-row.html.twig
@@ -50,7 +50,8 @@
   'paragraph',
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ? 'paragraph--unpublished'
+  not paragraph.isPublished() ? 'paragraph--unpublished',
+  'layout-overflow'
 ]
 %}
 {{ attach_library('illinois_framework_theme/paragraph-icon-row') }}

--- a/templates/paragraphs/paragraph--image-gallery.html.twig
+++ b/templates/paragraphs/paragraph--image-gallery.html.twig
@@ -48,7 +48,8 @@
   'paragraph',
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ? 'paragraph--unpublished', 'full-width'
+  not paragraph.isPublished() ? 'paragraph--unpublished',
+  'full-width', 'layout-overflow'
 ]
 %}
 {{ attach_library('illinois_framework_theme/paragraph-image-gallery') }}

--- a/templates/paragraphs/paragraph--intro-home.html.twig
+++ b/templates/paragraphs/paragraph--intro-home.html.twig
@@ -64,7 +64,8 @@
     'paragraph',
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-    not paragraph.isPublished() ? 'paragraph--unpublished'
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+  'layout-overflow'
   ]
 %}
 {{ attach_library('illinois_framework_theme/paragraph-intro') }}

--- a/templates/paragraphs/paragraph--list.html.twig
+++ b/templates/paragraphs/paragraph--list.html.twig
@@ -44,7 +44,8 @@
   'paragraph',
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ? 'paragraph--unpublished'
+  not paragraph.isPublished() ? 'paragraph--unpublished',
+  'layout-overflow'
 ]
 %}
 {% block paragraph %}

--- a/templates/paragraphs/paragraph--rt.html.twig
+++ b/templates/paragraphs/paragraph--rt.html.twig
@@ -44,7 +44,7 @@
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
   not paragraph.isPublished() ? 'paragraph--unpublished',
-  'clearfix'
+  'clearfix', 'layout-overflow'
 ]
 %}
 {% set column_count = content.field_rt_column['#items']|length %}

--- a/templates/paragraphs/paragraph--vertical-tab.html.twig
+++ b/templates/paragraphs/paragraph--vertical-tab.html.twig
@@ -52,7 +52,8 @@
     'paragraph',
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-    not paragraph.isPublished() ? 'paragraph--unpublished'
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'layout-overflow'
   ]
 %}
 {{ attach_library('illinois_framework_theme/paragraph-vertical-tabs') }}


### PR DESCRIPTION
## 📝 Description
*Added a class to hide overflow and added that to paragraph templates*

Fixes # 1140

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
