### PR TITLE
Fix content showing in sidebar region issue #1160

### DIFF
--- a/templates/layout/page--content-page.html.twig
+++ b/templates/layout/page--content-page.html.twig
@@ -63,15 +63,17 @@
       {# if a side navigation exists and /'latest' is not in the url #}
       {% if node.field_sidebar.0.value == 'sidebar' and '/latest' not in url|render|render %}
         <ilw-columns mode="sidebar-left" width="auto">
-          {{ page.sidebar_first }}
-          {{ page.sidebar_second }}
+          <div>
+            {{ page.sidebar_first }}
+            {{ page.sidebar_second }}
+          </div>
           <div>
               {# Render only the sidebar content here (blocks + body + sidebar paragraphs) #}
               {{ page.sidebar_content }}
           </div>
         </ilw-columns>
         {# Full-width paragraphs appear outside the columns #}
-          {{ page.full_width_paragraphs }}
+        {{ page.full_width_paragraphs }}
       {% else %}
         {# No sidebar - render everything from page.content, wrapping body with page width #}
         {% for key, item in page.content %}


### PR DESCRIPTION
## 📝 Description
Fixes #1160 

The issue was that if the sidebar area was blank, no html structure was generated, and so the first content the ilw-columns tag would encounter would be the actual content, which meant it would show the content in the sidebar region.

To solve the issue, I added a `<div>` tag around the sidebar area, which forces the sidebar to render and puts the content in the proper place.

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)
