### PR TITLE
added if check for accordion title and heading level changes to h2

### DIFF
--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -254,6 +254,27 @@ function illinois_framework_theme_preprocess_paragraph(&$variables) {
   }
 }
 
+/**
+ * Implements hook_preprocess_HOOK() for paragraph--accordion-content.html.twig.
+ */
+function illinois_framework_theme_preprocess_paragraph__accordion_content(array &$variables) {
+  $variables['has_parent_title'] = FALSE;
+
+  $paragraph = $variables['paragraph'] ?? NULL;
+  if (!$paragraph instanceof ParagraphInterface) {
+    return;
+  }
+
+  $parent = $paragraph->getParentEntity();
+  if (!$parent instanceof ParagraphInterface) {
+    return;
+  }
+
+  if ($parent->hasField('field_accordion_title') && !$parent->get('field_accordion_title')->isEmpty()) {
+    $variables['has_parent_title'] = TRUE;
+  }
+}
+
 function illinois_framework_theme_preprocess_breadcrumb(&$variables) {
   if ($variables['breadcrumb']) {
     $request = \Drupal::request();

--- a/templates/paragraphs/paragraph--accordion-content.html.twig
+++ b/templates/paragraphs/paragraph--accordion-content.html.twig
@@ -46,12 +46,17 @@
   not paragraph.isPublished() ? 'paragraph--unpublished',
 ]
 %}
+{% set has_title = has_parent_title|default(false) %}
 {% block paragraph %}
   {# Paragraph ID used for anchor linking #}
   <div {{ attributes.setAttribute('id', 'paragraph--' ~ paragraph.id() ) }} {{ attributes.addClass(classes) }}>
     {% block content %}
       <ilw-accordion-panel>
-        <h3 slot="summary">{{ content.field_accordion_summary }}</h3>
+        {% if has_title %}
+          <h3 slot="summary">{{ content.field_accordion_summary }}</h3>
+        {% else %}
+          <h2 slot="summary">{{ content.field_accordion_summary }}</h2>
+        {% endif %}
         {{ content.field_accordion_details }}
       </ilw-accordion-panel>
     {% endblock %}


### PR DESCRIPTION


## 📝 Description
*added if check for accordion title and heading level changes to h2 if there is no title*

Fixes #1145

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
