### PR TITLE
make site name an h1 on the homepage only

### DIFF
--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -707,3 +707,11 @@ function illinois_framework_theme_preprocess_field(array &$variables) {
     }
   }
 }
+/**
+ * Implements hook_preprocess_HOOK() for region.html.twig.
+ *
+ * This adds a variable to identify if the current page is the front page, which can be used for conditional logic in region templates.
+ */
+function illinois_framework_theme_preprocess_region(array &$variables): void {
+  $variables['is_front'] = \Drupal::service('path.matcher')->isFrontPage();
+}

--- a/templates/region/region--header.html.twig
+++ b/templates/region/region--header.html.twig
@@ -16,17 +16,13 @@
   {% if if_secondary_site_link %}
     <a slot="primary-unit" href="{{ if_secondary_site_link }}">{{ if_secondary_site_title }}</a>
   {% else %}
-    {% if is_front %}
-      <h1 slot="site-name" ><a href="#">{{ if_secondary_site_title }}</a></h1>
-    {% else %}
-      <a slot="site-name" href="#">{{ if_secondary_site_title }}</a>
-    {% endif %}
+    <div slot="primary-unit">{{ if_secondary_site_title }}</div>
   {% endif %}
 {% endif %}
 {% if is_front %}
-    <h1 slot="site-name" ><a href="/">{{ drupal_config('system.site', 'name') | raw }}</a></h1>
+  <h1 slot="site-name" ><a href="/">{{ drupal_config('system.site', 'name') | raw }}</a></h1>
 {% else %}
-<a slot="site-name" href="/">{{ drupal_config('system.site', 'name') | raw }}</a>
+  <a slot="site-name" href="/">{{ drupal_config('system.site', 'name') | raw }}</a>
 {% endif %}
 <form slot="search" method="get" action="/search/node" role="search">
   <input type="search" name="keys" aria-labelledby="search-button">

--- a/templates/region/region--header.html.twig
+++ b/templates/region/region--header.html.twig
@@ -16,10 +16,18 @@
   {% if if_secondary_site_link %}
     <a slot="primary-unit" href="{{ if_secondary_site_link }}">{{ if_secondary_site_title }}</a>
   {% else %}
-    <a slot="site-name" href="#">{{ if_secondary_site_title }}</a>
+    {% if is_front %}
+      <h1 slot="site-name" ><a href="#">{{ if_secondary_site_title }}</a></h1>
+    {% else %}
+      <a slot="site-name" href="#">{{ if_secondary_site_title }}</a>
+    {% endif %}
   {% endif %}
 {% endif %}
+{% if is_front %}
+    <h1 slot="site-name" ><a href="/">{{ drupal_config('system.site', 'name') | raw }}</a></h1>
+{% else %}
 <a slot="site-name" href="/">{{ drupal_config('system.site', 'name') | raw }}</a>
+{% endif %}
 <form slot="search" method="get" action="/search/node" role="search">
   <input type="search" name="keys" aria-labelledby="search-button">
   <button id="search-button" type="submit">Search</button>


### PR DESCRIPTION
## 📝 Description
*Added h1 to site name on homepage only*

Fixes #1189

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
