### PR TITLE
Bugfix/robgasc/issue 1214 pagers for spotlight view need pagination component

### DIFF
--- a/templates/navigation/pager.html.twig
+++ b/templates/navigation/pager.html.twig
@@ -32,6 +32,5 @@
  */
 #}
 {% if items %}
-  {% set total_pages = items.last.href ? items.last.href|split('=')|last|number_format(0, '', '', '') : current %}
-  <ilw-pagination zerostart="true" pages="{{ total_pages }}" page="{{ current - 1 }}"></ilw-pagination>
+  <ilw-pagination zerostart="true" pages="{{ items.pages|length }}" page="{{ current - 1 }}"></ilw-pagination>
 {% endif %}

--- a/templates/navigation/views-mini-pager.html.twig
+++ b/templates/navigation/views-mini-pager.html.twig
@@ -1,0 +1,110 @@
+{#
+/**
+ * @file
+ * Theme override for a views mini-pager.
+ *
+ * Available variables:
+ * - heading_id: Pagination heading ID.
+ * - pagination_heading_level: The heading level to use for the pager.
+ * - items: List of pager items.
+ *
+ * @see template_preprocess_views_mini_pager()
+ */
+#}
+
+
+<style>
+.ilw-navigation{
+nav {
+  background: var(--ilw-color--background);
+  padding: 1px 0;
+}
+nav.page ul {
+  margin: 4px var(--ilw-margin--side, max(1.875rem, calc(50cqw - 37.5rem))) 4px;
+}
+ul {
+  padding: 0;
+  margin: 4px 0;
+  list-style: none;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+}
+li {
+  padding: 0;
+  list-style: none;
+}
+li.current, li.ellipsis, li.previous span, li.first span, li.next span, li.last span, li.pagecount span {
+  display: flex;
+  min-width: 24px;
+  justify-content: center;
+  padding: 12px 18px;
+  font-family: var(--il-font-sans);
+  font-size: 1.1875rem;
+  background: var(--ilw-color--background);
+  color: var(--ilw-color--control-text);
+  border-color: var(--ilw-color--control-text);
+  outline: solid thin var(--ilw-color--control-text);
+}
+li.current {
+  background-color: var(--ilw-color--control-text);
+  color: var(--ilw-color--control);
+}
+li.ellipsis {
+  color: var(--ilw-color--control-text);
+  background: none;
+}
+li.pagecount span {
+  margin-left: 20px;
+}
+a {
+  font-weight: 500;
+  text-decoration: none;
+  color: var(--ilw-color--control-text);
+  background: var(--ilw-color--control);
+}
+a:hover {
+  color: var(--ilw-color--control);
+  background: var(--ilw-color--control-text);
+  text-decoration: underline;
+}
+a:focus {
+  background: var(--ilw-color--focus--background);
+  color: var(--ilw-color--focus--text);
+  border-color: var(--ilw-color--focus--outline);
+  text-decoration: underline;
+}
+}
+</style>
+{% if items.previous or items.next %}
+  <nav class="ilw-navigation page" role="navigation" aria-labelledby="{{ heading_id }}">
+    <{{ pagination_heading_level }} id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</{{ pagination_heading_level }}>
+    <ul>
+      {% if items.previous %}
+        <li class="previous">
+          <a href="{{ items.previous.href }}" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Previous page'|t }}</span>
+            <span aria-hidden="true">{{ items.previous.text|default('‹‹'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {% if items.current %}
+        <li class="current">
+          {% trans %}
+            Page {{ items.current }}
+          {% endtrans %}
+        </li>
+      {% endif %}
+      {% if items.next %}
+        <li class="next">
+          <a href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Next page'|t }}</span>
+            <span aria-hidden="true">{{ items.next.text|default('››'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </nav>
+{% endif %}


### PR DESCRIPTION
## 📝 Description
Makes a minor change to the pagination template that stops an extra page being added at the end.
Adds a new template for the mini pager to style it close to the full pagination.

Fixes #1214

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---