### PR TITLE
adding a 404 class to page template to control margins

### DIFF
--- a/css/node/node.css
+++ b/css/node/node.css
@@ -16,3 +16,9 @@ main.is-unpublished:before {
   display: block;
   font-weight: bold;
 }
+
+main.is-404 > div:first-of-type {
+  margin: 0 auto;
+  padding: 0 var(--ilw-margin--side, 0) 2rem;
+  width: 100%;
+}

--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -254,6 +254,11 @@ function illinois_framework_theme_form_user_login_form_alter(&$form, FormStateIn
  * Implements hook_preprocess_HOOK() for page.html.twig.
  */
 function illinois_framework_theme_preprocess_page(array &$variables): void {
+  //adds a class to 404 page to control margins
+  if (\Drupal::routeMatch()->getRouteName() === 'system.404') {
+    $variables['attributes']['class'][] = 'is-404';
+  }
+
   // Get the current node from the route match.
   $route_match = \Drupal::routeMatch();
   $node = $route_match->getParameter('node') ?: $route_match->getParameter('node_preview');


### PR DESCRIPTION
## 📝 Description
*adding a 404 class to page template to control margins*

Fixes #1200

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
