### PR TITLE
Fix for #1223 - Duplicate paragraphs on blog, news, and spotlights

### DIFF
--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -295,8 +295,8 @@ function illinois_framework_theme_preprocess_page(array &$variables): void {
       }
     }
 
-    // Only proceed with paragraph splitting if sidebar mode is active.
-    if ($variables['node_has_sidebar']) {
+    // Only proceed with paragraph splitting if it is a content_page and sidebar mode is active.
+    if ($node->bundle() === 'content_page' && $variables['node_has_sidebar']) {
       // Determine the split point.
       $split_at = 0;
       if ($node->hasField('field_sidebar_paragraphs') && !$node->get('field_sidebar_paragraphs')->isEmpty()) {
@@ -415,8 +415,8 @@ function illinois_framework_theme_preprocess_node(array &$variables): void {
     }
   }
 
-  // Logic should only run in 'full' or 'preview' view mode.
-  if ($variables['view_mode'] === 'full' || $variables['view_mode'] === 'preview') {
+  // Only remove paragraphs from the main content if it's a content_page in full or preview mode, and the sidebar is active.
+  if ($node->bundle() === 'content_page' && ($variables['view_mode'] === 'full' || $variables['view_mode'] === 'preview')) {
     // If sidebar mode is active, hide the paragraphs that were moved to the page variable.
     if ($node_has_sidebar) {
       $split_at = 0;

--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -252,6 +252,12 @@ function illinois_framework_theme_form_user_login_form_alter(&$form, FormStateIn
 
 /**
  * Implements hook_preprocess_HOOK() for page.html.twig.
+ *
+ * This function handles multiple responsibilities related to page preprocessing:
+ * - Puts "full width" paragraphs into a page-level variable so they can be rendered in a different part of the template.
+ * - Adding a class to the body for 404 pages.
+ * - Managing the logic for showing/hiding the sidebar based on node fields.
+ *
  */
 function illinois_framework_theme_preprocess_page(array &$variables): void {
   // Get the current node from the route match.
@@ -392,14 +398,27 @@ function _illinois_framework_theme_get_preview_sidebar_menu(NodeInterface $node)
 
 /**
  * Implements hook_preprocess_HOOK() for node.html.twig.
+ *
+ * This function handles the logic for splitting paragraphs into main content
+ * and sidebar based on the node's field_sidebar_paragraphs value, but only if
+ * the sidebar is active. It also ensures this logic only runs in 'full' or
+ * 'preview' view modes to avoid unintended consequences in teasers or other
+ * view modes.
  */
 function illinois_framework_theme_preprocess_node(array &$variables): void {
   $node = $variables['node'];
 
+  $node_has_sidebar = TRUE;
+  if ($node->hasField('field_sidebar') && !$node->get('field_sidebar')->isEmpty()) {
+    if ($node->get('field_sidebar')->value === 'nosidebar') {
+      $node_has_sidebar = FALSE;
+    }
+  }
+
   // Logic should only run in 'full' or 'preview' view mode.
   if ($variables['view_mode'] === 'full' || $variables['view_mode'] === 'preview') {
     // If sidebar mode is active, hide the paragraphs that were moved to the page variable.
-    if ($node->hasField('field_sidebar') && $node->get('field_sidebar')->value === 'sidebar') {
+    if ($node_has_sidebar) {
       $split_at = 0;
       if ($node->hasField('field_sidebar_paragraphs') && !$node->get('field_sidebar_paragraphs')->isEmpty()) {
         $split_at = (int) $node->get('field_sidebar_paragraphs')->value;


### PR DESCRIPTION
## 📝 Description
Updates the logic in the preprocess_node hook to match the conditionals for checking if a sidebar exists as the preprocess_page hook.

Fixes #1223 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
