### PR TITLE
removed il-orange from h2 and style-lint cleanup

### DIFF
--- a/css/node/node.news.css
+++ b/css/node/node.news.css
@@ -1,14 +1,14 @@
 /* article.news */
 
 article.news {
-
-  /*adjustments to main content width*/
+  /* adjustments to main content width */
   .field--name-body,
   .field--name-field-if-story-source,
   .field--name-field-tags,
   .field--name-field-paragraph {
     max-width: 900px !important;
-    @media (min-width: 1000px)  {
+
+    @media (width >= 1000px)  {
       margin: 0 auto !important;
     }
   }
@@ -20,12 +20,14 @@ article.news {
     margin-bottom: 1.875rem;
     color: var(--il-orange);
   }
+
   .field--name-field-if-author {
     padding: 1rem 0;
     color: var(--il-blue);
     font-weight: 600;
     float: left;
-      &:after{
+
+      &::after{
         content: "";
         display: inline-block;
         width: 2px;
@@ -34,6 +36,7 @@ article.news {
         margin: -10px 1rem;
       }
   }
+
   .field--name-field-if-date {
     border-top: 1px solid #d8d8d8;
     border-bottom: 1px solid #d8d8d8;
@@ -41,26 +44,28 @@ article.news {
     line-height: 1.75rem;
     color: var(--il-blue);
     font-weight: 600;
-    margin: 0 0 1.875rem 0;
+    margin: 0 0 1.875rem;
   }
+
   .field--name-field-if-meda-featured-image {
     float: none;
     padding: 1.875rem 1.5rem 0;
     max-width: 600px;
     margin: 0 auto;
+
     .field__item {
       display: flex;
+
       img {
         margin: 0 auto;
       }
     }
   }
+
   .field--name-body {
     padding: 1.875rem 0 !important;
-    h2 {
-      color: var(--il-orange) !important;
-    }
   }
+
   .field--name-field-if-story-source {
     font-weight: 600;
     font-style: oblique;
@@ -68,12 +73,14 @@ article.news {
     padding: 1.125rem 0;
     display: flex;
     gap: 1rem;
+
     .field__label{
-      &:after{
+      &::after{
         content: ":";
       }
     }
   }
+
   .field--name-field-tags {
     font-style: oblique;
     font-weight: 600;
@@ -82,21 +89,25 @@ article.news {
     padding: 1.125rem 0;
     display: flex;
     gap: 1rem;
+
     .field__label{
-      &:after{
+      &::after{
         content: ":";
       }
     }
+
     .field__items {
       display: flex;
       gap: 1rem;
     }
   }
+
   .paragraph {
     .fixed-width {
       padding: 0;
     }
   }
+
   /* hides featured image if featured_image_toggle field is true */
   &.hide-image {
     .field--name-field-if-meda-featured-image {
@@ -109,10 +120,12 @@ article.news {
 .news-page .news-title {
   font-weight: 600;
 }
+
 .news-page .item-list ul {
   list-style: none;
   padding-inline-start: 0;
 }
+
 .news-page .item-list li {
   padding: 1.875rem 0;
   border-bottom: 2px solid #d8d8d8;
@@ -120,48 +133,59 @@ article.news {
   list-style: none;
   overflow: auto;
 }
+
 .news-page .views-field-body {
   padding-left: 7.8125rem;
 }
+
 .news-page .views-field-field-if-meda-featured-image {
   float: left;
 }
 
 
-/*news blocks more news*/
+/* news blocks more news */
 .news-block {
   margin: 0 auto;
   max-width: 900px;
   padding: 0 var(--ilw-margin--side, 0);
-  @media (min-width: 600px) {
+
+  @media (width >= 600px) {
     padding: 0;
   }
+
   .item-list {
     width: auto;
+
     ul {
       padding-inline-start: 0;
+
       li {
         padding: 1.0rem 0;
         border-bottom: 1px solid #C6C7C7;
         margin: 0;
         list-style: none;
-        &:before {
+
+        &::before {
           content: "\25A0";
           padding-right: 1rem;
           float: left;
           color: #C6C7C7;
         }
       }
+
       li:last-child {
         border-bottom: none;
       }
     }
+
     .title {
       font-size: 1.25rem;
       line-height: 1.75rem;
       font-weight: 400;
+
       a {
         text-decoration: none;
+
         &:hover,
         &:focus {
           text-decoration: underline;
@@ -184,18 +208,22 @@ article.news {
   }
 }
 
-/*highlighted news block*/
+/* highlighted news block */
 .highlighted-news {
   margin: 0 auto;
   max-width: 900px;
+
   &.fixed-width {
     padding: 0;
   }
+
   .item-list {
     width: auto;
+
     ul {
       list-style: none;
       padding-inline-start: 0;
+
       li {
         padding: 1.875rem 0;
         border-bottom: 2px solid var(--il-cloud-3);
@@ -203,6 +231,7 @@ article.news {
         list-style: none !important;
         overflow: auto;
       }
+
       li:last-child {
         border-bottom: none;
       }
@@ -212,7 +241,8 @@ article.news {
   a{
     &.readmore{
       text-decoration: none;
-      &:after {
+
+      &::after {
         content: "\f054";
         display: inline-block;
         font-family: FontAwesome;
@@ -221,10 +251,12 @@ article.news {
         font-size: 0.75rem;
         text-decoration: none;
       }
+
       &:hover {
         text-decoration: underline;
       }
-      &:hover:after {
+
+      &:hover::after {
         text-decoration: none !important;
       }
     }
@@ -235,15 +267,19 @@ article.news {
       clear: both;
     }
   }
+
   .highlighted-news-wrapper {
     display: block;
-    @media (min-width: 600px)  {
+
+    @media (width >= 600px)  {
       display: flex;
     }
+
     .highlighted-news-image {
       width: 100%;
       margin-top: 20px;
     }
+
     .highlighted-news-content {
       max-width: 850px;
       padding-right: 50px;
@@ -253,9 +289,11 @@ article.news {
         font-size: 1.625rem;
         line-height: 2rem;
         margin-top: 0;
+
         a {
           color: var(--il-orange);
           text-decoration: none;
+
           &:hover,
           &:focus {
             color: var(--il-altgeld);
@@ -263,8 +301,9 @@ article.news {
           }
         }
       }
+
       .button {
-        margin: auto 0 0 0;
+        margin: auto 0 0;
         padding-left: 0;
       }
     }
@@ -272,7 +311,7 @@ article.news {
 
 }
 
-/*Styles for the news teaser template.*/
+/* Styles for the news teaser template. */
 .news-list-item {
   .media--view-mode-news-teaser {
     padding-right: calc(var(--il-content-margin) * 1.5);
@@ -298,36 +337,44 @@ article.news {
   flex-wrap: wrap;
   gap: 2rem 3%;
   flex-basis: 100%;
-  @media (min-width: 768px) {
+
+  @media (width >= 768px) {
     gap: 2.25rem 3%;
   }
+
     &.hvrbox-col-2 {
       > div {
-        @media (min-width: 600px) {
+        @media (width >= 600px) {
           flex-basis: 48%;
         }
       }
+
       header {
         flex: 0 0 100%;
-        margin-bottom: -2.25rem; /*overrides flex gap to remove excess space between header and news cards*/
+        margin-bottom: -2.25rem; /* overrides flex gap to remove excess space between header and news cards */
       }
+
       footer {
         flex: 0 0 100%;
+
         p{
           text-align: center;
           margin-bottom: 2.25rem;
         }
       }
+
       .hvrbox {
         .hvrbox-title {
           font-size: 1.25rem;
           line-height: 1.6875rem;
           font-weight: 700;
-          @media (min-width: 992px) {
+
+          @media (width >= 992px) {
             font-size: 1.8125rem;
             line-height: 2.1875rem;
           }
         }
+
           .hvrbox-body {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -335,6 +382,7 @@ article.news {
           -webkit-line-clamp: 6; /* number of lines to show */
                   line-clamp: 6;
           -webkit-box-orient: vertical;
+
           .field--name-body {
             padding: 0;
           }
@@ -342,33 +390,41 @@ article.news {
       }
 
     }
+
     &.hvrbox-col-3 {
       > div {
         flex-basis: 100%;
-        @media (min-width: 768px) {
+
+        @media (width >= 768px) {
           flex-basis: 48%;
         }
-          @media (min-width: 600px) {
+
+          @media (width >= 600px) {
             flex-basis: 31%;
           }
       }
+
       header {
         flex: 0 0 100%;
-        margin-bottom: -2.25rem; /*overrides flex gap to remove excess space between header and news cards*/
+        margin-bottom: -2.25rem; /* overrides flex gap to remove excess space between header and news cards */
       }
+
       footer {
         flex: 0 0 100%;
+
         p{
           text-align: center;
           margin-bottom: 2.25rem;
         }
       }
+
       .hvrbox {
         .hvrbox-title {
           font-size: 1.25rem;
           line-height: 1.6875rem;
           font-weight: 700;
         }
+
         .hvrbox-body {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -377,32 +433,38 @@ article.news {
                   line-clamp: 3;
           -webkit-box-orient: vertical;
         }
+
         .hvrbox-layer_slideup {
-          -moz-transform: translateY(50%);
-          -webkit-transform: translateY(50%);
-          -ms-transform: translateY(50%);
+          transform: translateY(50%);
+          transform: translateY(50%);
+          transform: translateY(50%);
           transform: translateY(50%);
         }
       }
     }
+
     .hvrbox {
       position: relative;
       overflow: hidden;
       height: auto;
       border: 1px solid #707070;
+
       .field--name-field-if-meda-featured-image {
         padding: 0;
         float:  none;
       }
+
         img {
           max-width: 100%;
           width: 100%;
           height: auto;
         }
+
         .hvrbox-title {
           color: #13294B;
           margin-bottom: 1.25rem;
-          &:after {
+
+          &::after {
             content: '\f101';
             font-family: FontAwesome;
             vertical-align: bottom;
@@ -410,36 +472,38 @@ article.news {
             position: absolute;
           }
         }
+
         .hvrbox-body{
           opacity: 0;
           font-size: 1.25rem;
           line-height: 1.6875rem;
           font-weight: 500;
-          -moz-transition: all 0.4s ease-in-out 0s;
-          -webkit-transition: all 0.4s ease-in-out 0s;
-          -ms-transition: all 0.4s ease-in-out 0s;
           transition: all 0.4s ease-in-out 0s;
+          transition: all 0.4s ease-in-out 0s;
+          transition: all 0.4s ease-in-out 0s;
+          transition: all 0.4s ease-in-out 0s;
+
           .field--name-body {
             padding: 0 !important;
           }
         }
+
         .hvrbox-layer_bottom {
           display: block;
         }
+
         .hvrbox-layer_top {
           position: absolute;
-          top: 0;
-          left: 0;
-          right: 0;
-          bottom: 0;
+          inset: 0;
           width: 100%;
           height: 100%;
-          background: rgba(255, 255, 255, 0.8);
-          padding: 10px 15px 0px 15px;
-          -moz-transition: all 0.4s ease-in-out 0s;
-          -webkit-transition: all 0.4s ease-in-out 0s;
-          -ms-transition: all 0.4s ease-in-out 0s;
+          background: rgb(255 255 255 / 80%);
+          padding: 10px 15px 0;
           transition: all 0.4s ease-in-out 0s;
+          transition: all 0.4s ease-in-out 0s;
+          transition: all 0.4s ease-in-out 0s;
+          transition: all 0.4s ease-in-out 0s;
+
             > a {
               display: block;
               position: absolute;
@@ -450,25 +514,29 @@ article.news {
               background-color: transparent;
             }
         }
+
         .hvrbox-layer_slideup {
-          -moz-transform: translateY(65%);
-          -webkit-transform: translateY(65%);
-          -ms-transform: translateY(65%);
+          transform: translateY(65%);
+          transform: translateY(65%);
+          transform: translateY(65%);
           transform: translateY(65%);
         }
+
         &:hover,
         &:focus-within,
         &:active {
           .hvrbox-layer_slideup {
-          -moz-transform: translateY(0);
-          -webkit-transform: translateY(0);
-          -ms-transform: translateY(0);
           transform: translateY(0);
-          background: rgba(255, 255, 255, 1);
+          transform: translateY(0);
+          transform: translateY(0);
+          transform: translateY(0);
+          background: rgb(255 255 255 / 100%);
         }
+
         .hvrbox-body {
           opacity: 1;
         }
+
         .hvrbox-title {
           color: var(--il-orange);
           transition: all 0.4s;


### PR DESCRIPTION
## 📝 Description
*removed color style on h2*

Fixes #1199 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
