### PR TITLE
Fix for content slider paragraph width issue #1239

### DIFF
--- a/css/paragraphs/paragraphs.content-slider.css
+++ b/css/paragraphs/paragraphs.content-slider.css
@@ -1,6 +1,11 @@
 .paragraph--type--content-slider{
   .paragraph--type--content-slider__wrapper{
-    padding: 0 30px;
+    max-width: 100vw;
+  }
+  @media (min-width: 600px) {
+     .paragraph--type--content-slider__wrapper{
+      padding: 0 30px;
+    }
   }
   ilw-content {
     text-align: center;


### PR DESCRIPTION
## 📝 Description
Adds a `max-width: 100vw;` to the class `.paragraph--type--content-slider__wrapper`. 

Fixes #1239 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
