### PR TITLE
Update visited link color to match Figma style

### DIFF
--- a/css/base/reset.css
+++ b/css/base/reset.css
@@ -31,8 +31,16 @@ a {
   cursor:pointer;
 }
 
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+  color: var(--ilw-color--heading-link);
+}
+
 a:visited {
-  color:var(--ilw-color--link-visited);
+  color:var(--il-industrial-darker-1);
+}
+
+h1 a:visited, h2 a:visited, h3 a:visited, h4 a:visited, h5 a:visited, h6 a:visited {
+  color: var(--il-blue);
 }
 
 a:hover {

--- a/css/base/reset.css
+++ b/css/base/reset.css
@@ -39,10 +39,6 @@ a:visited {
   color:var(--il-industrial-darker-1);
 }
 
-h1 a:visited, h2 a:visited, h3 a:visited, h4 a:visited, h5 a:visited, h6 a:visited {
-  color: var(--il-blue);
-}
-
 a:hover {
   color:var(--ilw-color--link-hover);
 }


### PR DESCRIPTION
## 📝 Description
This PR updates the visited link color to `--il-industrial-darker-1`, which is what it is supposed to be for headings and body text according to the Figma file. 

It also sets the heading link color since it is different than body text link color

Fixes #1258 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
