### PR TITLE
Remove the extra padding being added to field--name-body, and overrid…

### DIFF
--- a/css/node/node.css
+++ b/css/node/node.css
@@ -1,7 +1,3 @@
-.field--name-body {
-  padding-bottom: 2rem;
-}
-
 main.without-sidebar div.node-body-field-full-display {
   margin: var(--ilw-content--main-margin, 0);
 }

--- a/css/node/node.news.css
+++ b/css/node/node.news.css
@@ -62,10 +62,6 @@ article.news {
     }
   }
 
-  .field--name-body {
-    padding: 1.875rem 0 !important;
-  }
-
   .field--name-field-if-story-source {
     font-weight: 600;
     font-style: oblique;
@@ -382,10 +378,6 @@ article.news {
           -webkit-line-clamp: 6; /* number of lines to show */
                   line-clamp: 6;
           -webkit-box-orient: vertical;
-
-          .field--name-body {
-            padding: 0;
-          }
         }
       }
 
@@ -482,10 +474,6 @@ article.news {
           transition: all 0.4s ease-in-out 0s;
           transition: all 0.4s ease-in-out 0s;
           transition: all 0.4s ease-in-out 0s;
-
-          .field--name-body {
-            padding: 0 !important;
-          }
         }
 
         .hvrbox-layer_bottom {

--- a/templates/field/field--body.html.twig
+++ b/templates/field/field--body.html.twig
@@ -57,7 +57,7 @@
 {% if label_hidden %}
   {% if multiple %}
     <div{{ attributes.addClass(classes, 'field__items') }}>
-      <ilw-content transparent="true" {{ attributes.addClass(classes, 'ilw_content') }}>
+      <ilw-content transparent="true" class="ilw_content">
       {% for item in items %}
         <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
       {% endfor %}
@@ -65,12 +65,12 @@
     </div>
   {% else %}
     {% for item in items %}
-      <div{{ attributes.addClass(classes, 'field__item') }}><ilw-content transparent="true" {{ attributes.addClass(classes, 'ilw_content') }}>{{ item.content }}</ilw-content></div>
+      <div{{ attributes.addClass(classes, 'field__item') }}><ilw-content transparent="true" class="ilw_content">{{ item.content }}</ilw-content></div>
     {% endfor %}
   {% endif %}
 {% else %}
   <div{{ attributes.addClass(classes) }}>
-    <ilw-content transparent="true" {{ attributes.addClass(classes, 'ilw_content') }}>
+    <ilw-content transparent="true" class="ilw_content">
     <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
     {% if multiple %}
     <div class="field__items">


### PR DESCRIPTION
…es that address it.

## 📝 Description
Removes the properties to alter the padding on field--name-body. This property is too generic and causes side-effects, and removing it addresses the problem just fine.

Also removes a repeat of the properties of the body on the ilw-content tag in the body field, because we don't need every attribute twice.

Fixes #1262 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
