### PR TITLE
Adjust the ils-component javascript in a local version of the library

### DIFF
--- a/components/ils-contentslider/contentslider.js
+++ b/components/ils-contentslider/contentslider.js
@@ -15,7 +15,7 @@ div.ils-contentslider {
     padding-right: 10px;
     scroll-behavior: smooth;
     width: 100%;
-    justify-content: center;
+    justify-content: safe center;
 }
 div.ils-contentslider ::slotted(*) {
     flex-shrink: 0;

--- a/components/ils-contentslider/contentslider.js
+++ b/components/ils-contentslider/contentslider.js
@@ -1,0 +1,132 @@
+const templateSlider = document.createElement('template');
+templateSlider.innerHTML = `<style>
+div.ils-contentslider-outer {
+    display: flex;
+    margin: auto;
+    padding: 20px 0;
+}
+div.ils-contentslider {
+    overflow-x: scroll;
+    display: flex;
+    grid-column-gap: 30px;
+    margin: 0 20px;
+    padding-right: 10px;
+    scroll-snap-type: x mandatory;
+    padding-right: 10px;
+    scroll-behavior: smooth;
+    width: 100%;
+    justify-content: center;
+}
+div.ils-contentslider ::slotted(*) {
+    flex-shrink: 0;
+    overflow: hidden;
+    scroll-snap-align: center;
+}
+button {
+    background-color: white;
+    display: inline-block;
+    padding: 0;
+    text-align: center;
+    text-decoration: none;
+    border: none;
+    transition: background-color .3s;
+    cursor: pointer;
+    width: 65px;
+}
+button:hover, button:focus {
+    border: none;
+}
+
+button.ils-contentslider-prev {
+    border-right: 0;
+}
+button svg {
+    color: white;
+    background: var(--il-blue);
+    border-radius: 45px;
+    width: 50px;
+    height: 50px;
+}
+button:hover svg, button:focus svg {
+    background: var(--il-orange);
+}
+
+button.ils-contentslider-prev svg {
+    transform: rotate(270deg);
+}
+button.ils-contentslider-next {
+    border-left: 0;
+}
+button.ils-contentslider-next svg {
+    transform: rotate(90deg);
+}
+@media only screen and (max-width: 550px) {
+  div.ils-contentslider-outer {
+    flex-direction: column;
+  }
+
+  button.ils-contentslider-prev, button.ils-contentslider-next {
+    width: 100%;
+  }
+}
+</style>
+<div class='ils-contentslider-outer'><button class='ils-contentslider-prev' aria-label='scroll back in content slider'>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="presentation">
+    <path fill="currentColor" d="M8 24l2.83 2.83L22 15.66V40h4V15.66l11.17 11.17L40 24 24 8 8 24z"></path>
+</svg>
+</button>
+<div class='ils-contentslider'><slot></slot></div>
+<button class='ils-contentslider-next' aria-label='scroll forward in content slider'>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="presentation">
+    <path fill="currentColor" d="M8 24l2.83 2.83L22 15.66V40h4V15.66l11.17 11.17L40 24 24 8 8 24z"></path>
+</svg>
+</button></div>`;
+
+class Slider extends HTMLElement {
+    static get observedAttributes() { return ['height', 'slide']; }
+
+    get height() { return this.getAttribute('height'); }
+    set height(value) { this.setAttribute('height', value); }
+    get slide() { return this.getAttribute('slide'); }
+    set slide(value) { this.setAttribute('slide', value); }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.appendChild(templateSlider.content.cloneNode(true));
+        this.shadowRoot.querySelector('button.ils-contentslider-next').addEventListener('click', () => {
+            let s = this.slide;
+            let w = this.shadowRoot.querySelector('div.ils-contentslider').offsetWidth;
+            if (w < s) {
+                s = w;
+            }
+            this.shadowRoot.querySelector('div.ils-contentslider').scrollBy(s, 0);
+        });
+        this.shadowRoot.querySelector('button.ils-contentslider-prev').addEventListener('click', () => {
+            let s = this.slide;
+            let w = this.shadowRoot.querySelector('div.ils-contentslider').offsetWidth;
+            if (w < s) {
+                s = w;
+            }
+            this.shadowRoot.querySelector('div.ils-contentslider').scrollBy(-s, 0);
+        });
+    }
+    connectedCallback() {
+        var h = this.height == null || this.height == '' ? "500px" : this.height;
+        let style = this.shadowRoot.querySelector('style');
+        style.innerHTML += `div.ils-contentslider {
+            height: ${h};
+        }
+        div.ils-contentslider ::slotted(*) {
+            max-height: ${h};
+        }`;
+    }
+
+    attributeChangedCallback(attrName, oldValue, newValue) {
+        if (attrName === 'height' && oldValue != newValue) {
+            this.height = newValue;
+        }
+    }
+}
+
+customElements.define('ils-contentslider', Slider);

--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -38,9 +38,7 @@ ils-contentslider:
         type: external
         minified: true
   js:
-    themes/contrib/illinois_framework_theme/components/ils-contentslider/contentslider.js:
-      type: external
-      minified: true
+    components/ils-contentslider/contentslider.js: {}
     js/paragraph-content-slider.js: { }
   dependencies:
     - core/jquery

--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -38,7 +38,7 @@ ils-contentslider:
         type: external
         minified: true
   js:
-    https://contrib.webtheme.illinois.edu/ils-contentslider/contentslider.min.js:
+    themes/contrib/illinois_framework_theme/components/ils-contentslider/contentslider.js:
       type: external
       minified: true
     js/paragraph-content-slider.js: { }

--- a/js/paragraph-content-slider.js
+++ b/js/paragraph-content-slider.js
@@ -1,3 +1,9 @@
 jQuery(function($) {
   $('ilw-columns .paragraph--type--content-slider ilw-content[width="auto"]').removeAttr('width');
+  $(document).ready(function() {
+    $('.ils-contentslider').attr({
+      "width": "100%",
+      "justify-content": "center"
+    })
+  })
 });


### PR DESCRIPTION
## 📝 Description
In this commit the ils-contentslider component library is pulled locally and adjusted with preferred attributes.  Preferrable would be to reset the attributes in the ilfw-drupal code, if this will not be adjusted by component maintainers.

**_See attempt for override in js/paragraph-content-slider.js_**

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
With Adjusted Library
<img width="3006" height="1540" alt="Screenshot 2026-05-07 at 12 15 24 PM" src="https://github.com/user-attachments/assets/7a424d38-0412-408f-a742-49c1e07bd954" />
Without Adjusted Library
<img width="3010" height="1652" alt="Screenshot 2026-05-07 at 12 22 28 PM" src="https://github.com/user-attachments/assets/11577c91-9375-4ba4-a1e5-d06676f0bd56" />
