### PR TITLE
Set toolkit CSS and JS to version 3.9

### DIFF
--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -33,11 +33,11 @@ toolkit-3:
   header: true
   css:
     theme:
-      https://cdn.toolkit.illinois.edu/3/toolkit.css:
+      https://cdn.toolkit.illinois.edu/3.9/toolkit.css:
         type: external
         minified: true
   js:
-    https://cdn.toolkit.illinois.edu/3/toolkit.js:
+    https://cdn.toolkit.illinois.edu/3.9/toolkit.js:
       type: external
       minified: true
       attributes:


### PR DESCRIPTION
Fixes #1277

## 📝 Description
Sets the version of the Toolkit in the 4.x branch to 3.9 so that the theme will stay consistent in the future.

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
