### PR TITLE
adding fixed-width class to fix margins on taxonomy page with sidebar

### DIFF
--- a/templates/views/views-view--taxonomy-term--page.html.twig
+++ b/templates/views/views-view--taxonomy-term--page.html.twig
@@ -33,10 +33,11 @@
 {%
   set classes = [
     dom_id ? 'js-view-dom-id-' ~ dom_id,
+    'fixed-width',
   ]
 %}
 <div{{ attributes.addClass(classes) }}>
-  <ilw-content width="page">
+  <ilw-content>
   {{ title_prefix }}
   {{ title }}
   {{ title_suffix }}


### PR DESCRIPTION
## 📝 Description
*removed width attribute from ilw-content and replaced it with fixed-width class*

Fixes #1269 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
