### PR TITLE
Issue #1281 - add way to override IL Toolkit URLs to theme

### DIFF
--- a/config/install/illinois_framework_theme.settings.yml
+++ b/config/install/illinois_framework_theme.settings.yml
@@ -61,3 +61,5 @@ if_subfooter_link_4: ''
 if_subfooter_text_5: ''
 if_subfooter_link_5: ''
 if_shibboleth_login_direct: true
+if_toolkit_css_url: ''
+if_toolkit_js_url: ''

--- a/config/schema/illinois_framework_theme.schema.yml
+++ b/config/schema/illinois_framework_theme.schema.yml
@@ -1,0 +1,10 @@
+illinois_framework_theme.settings:
+  type: theme_settings
+  label: 'Illinois Framework Theme settings'
+  mapping:
+    if_toolkit_css_url:
+      type: string
+      label: 'Toolkit CSS URL'
+    if_toolkit_js_url:
+      type: string
+      label: 'Toolkit JS URL'

--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -19,7 +19,7 @@ global:
 web-components:
   header: true
   css:
-    theme:
+    component:
       https://cdn.toolkit.illinois.edu/3/toolkit.css:
         type: external
         minified: true

--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -13,6 +13,58 @@ use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\paragraphs\ParagraphInterface;
 
 /**
+ * Returns the default Toolkit library URLs by parsing the libraries YAML file.
+ *
+ * This reads the raw YAML to avoid circular dependency with
+ * hook_library_info_alter() and to always reflect the file-based defaults
+ * regardless of any runtime overrides.
+ *
+ * @return array<string, string>
+ *   The default CSS and JS URLs.
+ */
+function illinois_framework_theme_get_web_components_library_defaults(): array {
+  static $defaults;
+  if ($defaults !== NULL) {
+    return $defaults;
+  }
+
+  $defaults = [
+    'css' => '',
+    'js' => '',
+  ];
+
+  $theme_path = \Drupal::service('extension.list.theme')->getPath('illinois_framework_theme');
+  $library_file = $theme_path . '/illinois_framework_theme.libraries.yml';
+
+  if (!file_exists($library_file)) {
+    return $defaults;
+  }
+
+  $libraries = \Drupal\Component\Serialization\Yaml::decode(file_get_contents($library_file));
+  if (!is_array($libraries) || empty($libraries['web-components'])) {
+    return $defaults;
+  }
+
+  $library = $libraries['web-components'];
+
+  if (!empty($library['css']['component']) && is_array($library['css']['component'])) {
+    $css_url = array_key_first($library['css']['component']);
+    if (is_string($css_url)) {
+      $defaults['css'] = $css_url;
+    }
+  }
+
+  if (!empty($library['js']) && is_array($library['js'])) {
+    $js_url = array_key_first($library['js']);
+    if (is_string($js_url)) {
+      $defaults['js'] = $js_url;
+    }
+  }
+
+  return $defaults;
+}
+
+/**
  * Implements hook_preprocess().
  */
 function illinois_framework_theme_preprocess(array &$variables) {
@@ -499,6 +551,44 @@ function illinois_framework_theme_preprocess_menu(array &$variables) {
 
       // Create the render array we'll use in the template.
       $variables['parent_a'] = $link_generator->generate($parent->getTitle(), $variables['parent_url']);
+    }
+  }
+}
+
+/**
+ * Implements hook_library_info_alter().
+ *
+ * This hooks allows us to override the default Toolkit library CSS and JS URLs,
+ * using the theme settings if they are provided.
+ *
+ * @param array $libraries
+ *   An associative array of libraries, passed by reference. The array key
+ *   for any particular library will be the name registered in *.libraries.yml.
+ *   In the example below, the array key would be $libraries['foo'].
+ *   @code
+ *   foo:
+ *     js:
+ *       .......
+ *   @endcode
+ * @param string $extension
+ *   Can either be 'core' or the machine name of the extension that registered
+ *   the libraries.
+ *
+ * @see \Drupal\Core\Asset\LibraryDiscoveryParser::parseLibraryInfo()
+ */
+function illinois_framework_theme_library_info_alter(&$libraries, $extension) {
+  if ($extension == 'illinois_framework_theme' && isset($libraries['web-components']) && (!empty(theme_get_setting('if_toolkit_css_url') || !empty(theme_get_setting('if_toolkit_js_url'))))) {
+    if (!empty(theme_get_setting('if_toolkit_css_url'))) {
+      // Clear the current CSS definition and replace it with the CDN URL from theme settings.
+      $libraries['web-components']['css']['component'] = [];
+      $cdn_css = theme_get_setting('if_toolkit_css_url');
+      $libraries['web-components']['css']['component'][$cdn_css] = ['type:' => 'external', 'minified' => TRUE];
+    }
+    if (!empty(theme_get_setting('if_toolkit_js_url'))) {
+      // Clear the current JS definition and replace it with the CDN URL from theme settings.
+      $libraries['web-components']['js'] = [];
+      $cdn_js = theme_get_setting('if_toolkit_js_url');
+      $libraries['web-components']['js'][$cdn_js] = ['type:' => 'external', 'minified' => TRUE, 'attributes' => ['blocking' => 'render', 'type' => 'module']];
     }
   }
 }

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -89,6 +89,35 @@ function illinois_framework_theme_form_system_theme_settings_alter(&$form, FormS
       '#title' => t('Link'),
   );
 
+  $library_defaults = illinois_framework_theme_get_web_components_library_defaults();
+
+  $form['if_toolkit'] = array(
+      '#type' => 'details',
+      '#title' => t('Illinois Toolkit Assets'),
+      '#description' => t('Override the Illinois Toolkit asset URLs. Leave a field blank to use the library default.<br><strong>Current library defaults:</strong><br>CSS: <code>@css_url</code><br>JS: <code>@js_url</code>', [
+        '@css_url' => $library_defaults['css'],
+        '@js_url' => $library_defaults['js'],
+      ]),
+      '#weight' => -95,
+      '#open' => FALSE,
+  );
+  $form['if_toolkit']['if_toolkit_css_url'] = array(
+      '#type' => 'url',
+      '#title' => t('Toolkit CSS URL'),
+      '#description' => t('Full URL for the Toolkit stylesheet. Leave blank to use the library default.'),
+      '#size' => 128,
+      '#default_value' => theme_get_setting('if_toolkit_css_url') ?: '',
+      '#placeholder' => $library_defaults['css'],
+  );
+  $form['if_toolkit']['if_toolkit_js_url'] = array(
+      '#type' => 'url',
+      '#title' => t('Toolkit JS URL'),
+      '#description' => t('Full URL for the Toolkit JavaScript module. Leave blank to use the library default.'),
+      '#size' => 128,
+      '#default_value' => theme_get_setting('if_toolkit_js_url') ?: '',
+      '#placeholder' => $library_defaults['js'],
+  );
+
   // Create a section for the footer links
   $form['if_footer'] = array(
       '#type' => 'details',


### PR DESCRIPTION
## 📝 Description
This PR adds theme settings `if_toolkit_css_url` and `if_toolkit_js_url` that when not empty, are used as an override of the IL Toolkit URLs defined in `illinois_framework_theme.libraries.yml` under the `web-components` key.

The theme settings page has a new "Illinois Toolkit Assets" section where you can specify one or both URLs.

Fixes #1281 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
<img width="1093" height="1241" alt="image" src="https://github.com/user-attachments/assets/5dee7dd1-c340-4e88-b4a1-e905b2a66e5e" />

