### PR TITLE
added closing bracket on div tag for field image gallery

### DIFF
--- a/templates/field/field--paragraph--field-image-gallery-img.html.twig
+++ b/templates/field/field--paragraph--field-image-gallery-img.html.twig
@@ -37,7 +37,7 @@
  */
 #}
 {% for item in items %}
-  <div class="image-gallery-item"
+  <div class="image-gallery-item">
   {{ item.content }}
   </div>
 {% endfor %}

--- a/templates/paragraphs/paragraph--image-gallery.html.twig
+++ b/templates/paragraphs/paragraph--image-gallery.html.twig
@@ -55,7 +55,7 @@
 {{ attach_library('illinois_framework_theme/paragraph-image-gallery') }}
 {% block paragraph %}
   {# Paragraph ID used for anchor linking #}
-  <div {{ attributes.setAttribute('id', 'paragraph--' ~ paragraph.id() ) }} {{ attributes.addClass(classes) }}>
+  <div {{ attributes.addClass(classes).setAttribute('id', 'paragraph--' ~ paragraph.id()) }}>
     {% block content %}
       <ilw-content theme="{{ theme }}" width="auto">
       <div class="field--name-field-image-gallery__wrapper">


### PR DESCRIPTION
## 📝 Description
*added closing bracket on div tag for field image gallery and cleaned up twig code*

Fixes #1292

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
