### PR TITLE
fixing the value of the background color in twig, removing width=auto

### DIFF
--- a/js/paragraph-rt.js
+++ b/js/paragraph-rt.js
@@ -1,7 +1,3 @@
 jQuery(function($) {
-  $('ilw-columns .paragraph--type--rt ilw-content[width="auto"]:not([theme="gray"])').removeAttr('width');
-  $('ilw-columns .paragraph--type--rt ilw-content[width="auto"][theme="gray"]').removeAttr('width').attr('padding', '20px 20px 30px');
-  $('ilw-columns .paragraph--type--rt ilw-columns[width="auto"]').removeAttr('width');
-  $('article.news .paragraph--type--rt ilw-content[width="auto"]').removeAttr('width');//fix for paragraphs in news content type
-  $('article.spotlight .paragraph--type--rt ilw-content[width="auto"]').removeAttr('width');//fix for paragraphs in spotlight content type
+  $('ilw-columns .paragraph--type--rt ilw-content[theme="gray"]').attr('padding', '20px 20px 30px');
 });

--- a/templates/paragraphs/paragraph--rt.html.twig
+++ b/templates/paragraphs/paragraph--rt.html.twig
@@ -44,12 +44,14 @@
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
   not paragraph.isPublished() ? 'paragraph--unpublished',
-  'clearfix', 'layout-overflow'
+  'clearfix'
 ]
 %}
 {% set column_count = content.field_rt_column['#items']|length %}
-{% set background = content.field_rt_background_color['#items'].0.value %}
-{% if background == 'Gray' %}
+{% set background = paragraph.field_rt_background_color.value|default('')|trim %}
+{% set theme = '' %}
+{% set padding = '' %}
+{% if background|lower == 'gray' %}
   {% set theme = 'gray' %}
   {% set padding = '20px 0 30px' %}
 {% endif %}
@@ -61,7 +63,8 @@
   <div {{ attributes.setAttribute('id', 'paragraph--' ~ paragraph.id() ) }} {{ attributes.addClass(classes) }}>
     {% block content %}
       {% if column_count == 1 %}
-        <ilw-content theme="{{ theme }}" width="auto" padding="{{ padding }}">
+        <ilw-content theme="{{ theme }}" padding="{{ padding }}">
+          <div class="fixed-width">
           {% if content.field_rt_title['#items'] %}
             <h2>{{ content.field_rt_title }}</h2>
           {% endif %}
@@ -76,6 +79,7 @@
               {{ body|check_markup(body_format) }}
             {% endif %}
           {% endfor %}
+          </div>
         </ilw-content>
       {% else %}
         <ilw-content width="auto">
@@ -90,12 +94,12 @@
             {% set body_format= content.field_rt_column[loop.index0]['#paragraph'].field_rt_content_body.format %}
             <div>
               <ilw-content theme="{{ theme }}">
-              {% if title %}
-                <h3>{{ title }}</h3>
-              {% endif %}
-              {% if body|trim %}
-                {{ body|check_markup(body_format) }}
-              {% endif %}
+                {% if title %}
+                  <h3>{{ title }}</h3>
+                {% endif %}
+                {% if body|trim %}
+                  {{ body|check_markup(body_format) }}
+                {% endif %}
               </ilw-content>
             </div>
           {% endfor %}


### PR DESCRIPTION
 fixing the value of the background color in twig, removing width=auto, and adding fixed-width class

## 📝 Description
*fixed the value of the background color for the gray not showing, and removed width=auto for the white line on the right*

Fixes #1294 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
