### PR TITLE
Fix paragraph types that use ilw content width auto for white margin on color background

### DIFF
--- a/css/node/node.blog.css
+++ b/css/node/node.blog.css
@@ -130,9 +130,11 @@ article.blog {
     }
   }
 
-  .paragraph {
-    .fixed-width {
-      padding: 0;
+  @media (width >= 600px) {
+    .paragraph--type--image-gallery {
+      .fixed-width {
+        padding: 0 2rem;
+      }
     }
   }
 

--- a/css/node/node.news.css
+++ b/css/node/node.news.css
@@ -102,9 +102,11 @@ article.news {
     }
   }
 
-  .paragraph {
-    .fixed-width {
-      padding: 0;
+  @media (width >= 600px) {
+    .paragraph {
+      .fixed-width {
+        padding: 0 2rem ;
+      }
     }
   }
 
@@ -500,7 +502,7 @@ article.news {
       height: 100%;
       padding: 10px 15px 0;
       transition: all 0.4s ease-in-out 0s;
-      background: rgb(255 255 255 / 0.8);
+      background: rgb(255 255 255 / 80%);
       inset: 0;
 
       > a {
@@ -523,7 +525,7 @@ article.news {
     &:active {
       .hvrbox-layer_slideup {
         transform: translateY(0);
-        background: rgb(255 255 255 / 1);
+        background: rgb(255 255 255 / 100%);
       }
 
       .hvrbox-body {

--- a/css/node/node.spotlight-family.css
+++ b/css/node/node.spotlight-family.css
@@ -2,39 +2,52 @@ article.spotlight.full {
   margin: 0 auto;
   padding: 0 var(--ilw-margin--side, 0);
   width: 100%;
+
   .node-body-field-full-display {
     margin: 0;
   }
+
+  @media (width >= 600px) {
+    .paragraph--type--image-gallery {
+      .fixed-width {
+        padding: 0 2rem ;
+      }
+    }
+  }
 }
-/*works around having the need for items after a body
+
+/* works around having the need for items after a body
 to float around an external image to that body.
-keeping it local to prevent compromising others use cases.*/
+keeping it local to prevent compromising others use cases. */
 .node-feature,
 .spotlight-list-item {
-  .clearfix .clearfix:after {
+  .clearfix .clearfix::after {
     clear: none;
   }
 }
 
 .field--name-field-if-meda-featured-image {
-  padding: 0 0 1.5rem 0;
-  @media (min-width: 600px) {
+  padding: 0 0 1.5rem;
+
+  @media (width >= 600px) {
     float: right;
     padding: 0 0 1.5rem 1.5rem;
   }
 }
 
-/*override to handle extra padding from double applying fixed-width*/
+/* override to handle extra padding from double applying fixed-width */
 #block-illinois-framework-theme-content article.fixed-width .field--name-body {
   padding: 0;
 }
 
-/*used for spotlight feature display view*/
+/* used for spotlight feature display view */
 .node-feature {
   overflow: auto;
+
   .body {
     margin-bottom: 1.813rem;
   }
+
   .spotlight-feature-image {
     float: right;
     padding-left: calc(var(--il-content-margin) * 1.5);
@@ -46,14 +59,16 @@ keeping it local to prevent compromising others use cases.*/
 
 }
 
-/*used for spotlight teaser display view*/
+/* used for spotlight teaser display view */
 .spotlight-list-item {
   ul.inline li {
     padding: 0;
   }
+
   .media--view-mode-spotlight-list {
     padding-right: calc(var(--il-content-margin) * 1.5);
   }
+
   .list-title {
     margin-top: 0;
   }

--- a/js/paragraph-icon-row.js
+++ b/js/paragraph-icon-row.js
@@ -1,5 +1,6 @@
 jQuery(function($) {
-  $('ilw-columns .paragraph--type--icon-row ilw-content[width="auto"], ilw-columns .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');
-  $('article.news .paragraph--type--icon-row ilw-content[width="auto"], article.news .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in news content type
-  $('article.spotlight .paragraph--type--icon-row ilw-content[width="auto"], article.spotlight .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in spotlight content type
+  $('ilw-columns .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');
+  $('article.news .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in news content type
+  $('article.spotlight .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in spotlight content type
+  $('article.blog .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in blog content type
 });

--- a/js/paragraph-image-gallery.js
+++ b/js/paragraph-image-gallery.js
@@ -1,5 +1,6 @@
 jQuery(function($) {
-  $('ilw-columns .paragraph--type--image-gallery ilw-content[width="auto"]').removeAttr('width');
-  $('ilw-columns .paragraph--type--image-gallery ilw-grid[width="auto"]').removeAttr('width');
-  $('article.news .paragraph--type--image-gallery ilw-grid[width="auto"], article.news .paragraph--type--image-gallery ilw-content[width="auto"]').removeAttr('width');//fix for paragraphs in news content type
+  $('ilw-columns .paragraph--type--image-gallery ilw-grid[width="page"]').removeAttr('width');
+  $('article.news .paragraph--type--image-gallery ilw-grid[width="page').removeAttr('width');//fix for paragraphs in other content types
+  $('article.spotlight .paragraph--type--image-gallery ilw-grid[width="page"]').removeAttr('width');
+  $('article.blog .paragraph--type--image-gallery ilw-grid[width="page"]').removeAttr('width');
 });

--- a/templates/paragraphs/paragraph--icon-row.html.twig
+++ b/templates/paragraphs/paragraph--icon-row.html.twig
@@ -50,8 +50,7 @@
   'paragraph',
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ? 'paragraph--unpublished',
-  'layout-overflow'
+  not paragraph.isPublished() ? 'paragraph--unpublished'
 ]
 %}
 {{ attach_library('illinois_framework_theme/paragraph-icon-row') }}
@@ -60,8 +59,10 @@
   <div {{ attributes.setAttribute('id', 'paragraph--' ~ paragraph.id() ) }} {{ attributes.addClass(classes) }}>
     {% block content %}
       {% if content.field_icon_row_title['#items'] %}
-        <ilw-content theme="{{ theme }}" width="auto">
-          <h2 class="field--name-field-icon-row__title title">{{ content.field_icon_row_title }}</h2>
+        <ilw-content theme="{{ theme }}">
+          <div class="fixed-width">
+            <h2 class="field--name-field-icon-row__title title">{{ content.field_icon_row_title }}</h2>
+          </div>
         </ilw-content>
       {% endif %}
       <div class="field--name-field-icon-row-content {{ content.field_icon_row_icon_size['#items'].0.value }}">

--- a/templates/paragraphs/paragraph--image-gallery.html.twig
+++ b/templates/paragraphs/paragraph--image-gallery.html.twig
@@ -48,8 +48,7 @@
   'paragraph',
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ? 'paragraph--unpublished',
-  'full-width', 'layout-overflow'
+  not paragraph.isPublished() ? 'paragraph--unpublished'
 ]
 %}
 {{ attach_library('illinois_framework_theme/paragraph-image-gallery') }}
@@ -57,9 +56,9 @@
   {# Paragraph ID used for anchor linking #}
   <div {{ attributes.setAttribute('id', 'paragraph--' ~ paragraph.id() ) }} {{ attributes.addClass(classes) }}>
     {% block content %}
-      <ilw-content theme="{{ theme }}" width="auto">
+      <ilw-content theme="{{ theme }}">
       <div class="field--name-field-image-gallery__wrapper">
-        <div class="field--name-field-image-gallery-text__wrapper">
+        <div class="fixed-width field--name-field-image-gallery-text__wrapper">
           {% if content.field_image_gallery_title.0 %}
             <h2 class="field--name-field-image-gallery__title title">{{ content.field_image_gallery_title }}</h2>
           {% endif %}
@@ -70,8 +69,8 @@
             <div class="field--name-field-image-gallery__body body">{{ content.field_image_gallery_body }}</div>
           {% endif %}
         </div>
-        <ilw-grid theme="{{ theme }}" width="auto">
-          {{ content.field_image_gallery_img }}
+        <ilw-grid width="page" theme="{{ theme }}">
+            {{ content.field_image_gallery_img }}
         </ilw-grid>
       </div>
       </ilw-content>


### PR DESCRIPTION
## 📝 Description
*removed width=auto from ilw-content and added fixed-width class for margins*

Fixes #1303 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
