### PR TITLE
adding solid orange and blue button colors to ckeditor

### DIFF
--- a/css/ck5style.css
+++ b/css/ck5style.css
@@ -227,13 +227,13 @@
     --ilw-button--focused-border-color: var(--il-orange);
   }
 
-  .ilw-theme-orange-1 {
+  .ilw-theme-orange-1, .ilw-theme-orange-solid {
     --ilw-button--background-color: var(--il-orange);
     --ilw-button--foreground-color: white;
     --ilw-button--border-color: var(--il-orange);
   }
 
-  .ilw-theme-blue-1 {
+  .ilw-theme-blue-1, .ilw-theme-blue-solid {
     --ilw-button--background-color: var(--il-blue);
     --ilw-button--foreground-color: white;
     --ilw-button--border-color: var(--il-blue);
@@ -251,18 +251,18 @@
     --ilw-button--border-color: white;
   }
 
-  .ilw-theme-orange, .ilw-theme-orange-1, .ilw-theme-orange-2 {
+  .ilw-theme-orange, .ilw-theme-orange-1, .ilw-theme-orange-2, .ilw-theme-orange-solid {
     --ilw-button--active-background-color: var(--il-blue);
     --ilw-button--active-border-color: var(--il-orange);
   }
 
-  .ilw-theme-orange-1, .ilw-theme-orange-2 {
+  .ilw-theme-orange-1, .ilw-theme-orange-2, .ilw-theme-orange-solid {
     --ilw-button--focused-background-color: white;
     --ilw-button--focused-foreground-color: var(--il-orange);
     --ilw-button--focused-border-color: var(--il-orange);
   }
 
-  .ilw-theme-blue-1, .ilw-theme-blue-2 {
+  .ilw-theme-blue-1, .ilw-theme-blue-2, .ilw-theme-blue-solid {
     --ilw-button--focused-background-color: white;
     --ilw-button--focused-foreground-color: var(--il-blue);
     --ilw-button--focused-border-color: var(--il-blue);


### PR DESCRIPTION
## 📝 Description
*Changed classes in ckeditor to more understandable colors for buttons*

Fixes #1271 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
