### PR TITLE
Vanilla js conversion

### DIFF
--- a/css/component/table.css
+++ b/css/component/table.css
@@ -70,11 +70,6 @@ tr:nth-child(odd) {
   background-color: var(--il-storm-lighter-4);
 }
 
-.with-sidebar .page-content-wrapper {
-  /* Let responsive tables scroll inside the sidebar column instead of widening it. */
-  min-width: 0;
-}
-
 .table-responsive-wrapper {
   max-width: 100%;
   overflow-x: auto;

--- a/css/component/table.css
+++ b/css/component/table.css
@@ -5,12 +5,18 @@ table {
   width: 100%;
   overflow: auto;
 
+  @media (width <= 599px) {
+    border: none;
+  }
+
   caption {
     padding: 0 0 1rem;
+    width: 100%;
   }
 }
 
 th {
+  box-sizing: border-box;
   text-align: left;
   font-weight: 700 !important;
   font-size: 1.2rem;
@@ -19,21 +25,7 @@ th {
   border-left: none;
   border-right: none;
   padding: .5rem .75rem;
-  vertical-align: top;
-}
-
-thead th {
-  background-color: var(--il-industrial);
-  color: white;
-  font-family: var(--il-source-sans);
-}
-
-th:first-of-type {
-  border-left: 1px solid var(--il-storm-lighter-3);
-}
-
-th:last-of-type {
-  border-right: 1px solid var(--il-storm-lighter-3);
+  vertical-align: middle;
 }
 
 thead th {
@@ -46,7 +38,16 @@ tbody th {
   color: var(--il-blue);
 }
 
+th:first-of-type {
+  border-left: 1px solid var(--il-storm-lighter-3);
+}
+
+th:last-of-type {
+  border-right: 1px solid var(--il-storm-lighter-3);
+}
+
 td {
+  box-sizing: border-box;
   text-align: left;
   vertical-align: top;
   padding: .5rem .75rem;
@@ -69,18 +70,30 @@ tr:nth-child(odd) {
   background-color: var(--il-storm-lighter-4);
 }
 
-.table-responsive-wrapper {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch; /* smoother scroll on iOS */
+.with-sidebar .page-content-wrapper {
+  /* Let responsive tables scroll inside the sidebar column instead of widening it. */
+  min-width: 0;
 }
 
-.table-responsive-wrapper table {
-  @media (width <= 599px) {
-    width: auto;
-  }
+.table-responsive-wrapper {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 @media (width <= 599px) {
+  .table-responsive-wrapper {
+    display: block;
+    inline-size: min(100%, calc(100vw - 3.75rem));
+    max-inline-size: calc(100vw - 3.75rem);
+  }
+
+  .table-responsive-wrapper > table {
+    width: 100%;
+    min-width: 40rem;
+  }
+
+  table.table-stack,
   .table-stack table,
   .table-stack thead,
   .table-stack tbody,

--- a/css/component/table.css
+++ b/css/component/table.css
@@ -70,6 +70,7 @@ tr:nth-child(odd) {
   background-color: var(--il-storm-lighter-4);
 }
 
+/* This is the default wrapper for all tables */
 .table-responsive-wrapper {
   max-width: 100%;
   overflow-x: auto;
@@ -88,6 +89,7 @@ tr:nth-child(odd) {
     min-width: 40rem;
   }
 
+  /* This is the stacked class for tables, class needs to be applied in ckeditor or in the html */
   table.table-stack,
   .table-stack table,
   .table-stack thead,

--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -11,7 +11,6 @@ global:
     js/table-mobile.js: {}
   dependencies:
     - core/drupal
-    - core/jquery
     - core/once
   css:
     theme:
@@ -46,12 +45,14 @@ ils-contentslider:
       minified: true
     js/paragraph-content-slider.js: { }
   dependencies:
-    - core/jquery
+    - core/drupal
+    - core/once
 google-cse:
   js:
     js/google-cse.js: { attributes: { async: true } }
   dependencies:
-    - core/jquery
+    - core/drupal
+    - core/once
     - core/drupalSettings
 ils-forms:
   css:
@@ -67,44 +68,72 @@ paragraph-rt:
   js:
     js/paragraph-rt.js: {}
   dependencies:
-    - core/jquery
+    - core/drupal
+    - core/once
 paragraph-list-content:
   js:
       js/paragraph-list-content.js: {}
   dependencies:
-    - core/jquery
+    - core/drupal
+    - core/once
 paragraph-contact:
   js:
     js/paragraph-contact.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 paragraph-bb:
   js:
     js/paragraph-bb.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 paragraph-card:
   js:
     js/paragraph-card.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 paragraph-cta-narrow:
   js:
     js/paragraph-cta-narrow.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 paragraph-feature-group:
   js:
     js/paragraph-feature-group.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 paragraph-icon-row:
   js:
     js/paragraph-icon-row.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 paragraph-image-gallery:
   js:
     js/paragraph-image-gallery.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 paragraph-vertical-tabs:
   js:
     js/paragraph-vertical-tab.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 paragraph-calendar:
   js:
     js/paragraph-calendar.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 skipto-campus:
   js:
     https://skipto-landmarks-headings.github.io/page-script-5/dist/skipto.min.js:
       attributes:
         data-skipto: "displayOption: popup;"
   dependencies:
-    - core/jquery
     - core/drupalSettings

--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -8,7 +8,9 @@ global:
       type: external
       attributes:
         async: true
+    js/table-mobile.js: {}
   dependencies:
+    - core/drupal
     - core/jquery
   css:
     theme:

--- a/illinois_framework_theme.libraries.yml
+++ b/illinois_framework_theme.libraries.yml
@@ -12,6 +12,7 @@ global:
   dependencies:
     - core/drupal
     - core/jquery
+    - core/once
   css:
     theme:
       css/style.css: {}

--- a/js/google-cse.js
+++ b/js/google-cse.js
@@ -1,10 +1,20 @@
-(function($) {
-  var google_api_key = drupalSettings.google_cse.google_api;
-  var cx = google_api_key;
-  var gcse = document.createElement('script');
-  gcse.type = 'text/javascript';
-  gcse.async = true;
-  gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
-  var s = document.getElementsByTagName('script')[0];
-  s.parentNode.insertBefore(gcse, s);
-}(jQuery));
+(function (Drupal, drupalSettings, once) {
+  Drupal.behaviors.googleCse = {
+    attach: function (context) {
+      once('googleCse', 'html', context).forEach(function () {
+        if (!drupalSettings.google_cse || !drupalSettings.google_cse.google_api) {
+          return;
+        }
+
+        const cx = drupalSettings.google_cse.google_api;
+        const gcse = document.createElement('script');
+        gcse.type = 'text/javascript';
+        gcse.async = true;
+        gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+
+        const s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(gcse, s);
+      });
+    }
+  };
+})(Drupal, drupalSettings, once);

--- a/js/paragraph-bb.js
+++ b/js/paragraph-bb.js
@@ -1,22 +1,44 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--bb ilw-content[width="page"], ilw-columns .paragraph--type--bb ilw-content[width="full"]').removeAttr('width');
-  $('ilw-columns .paragraph--type--bb ilw-grid[width="page"], ilw-columns .paragraph--type--bb ilw-grid[width="full"]').removeAttr('width');
-  $('article.news .paragraph--type--bb ilw-content[width="page"], article.news .paragraph--type--bb ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in news content type
-  $('article.spotlight .paragraph--type--bb ilw-content[width="page"], article.spotlight .paragraph--type--bb ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in news content type
-
+(function (Drupal, once) {
   function setFullWidthPadding() {
-    if (window.matchMedia('(max-width: 599px)').matches) {
-      $('.paragraph--type--bb ilw-content[width="full"]').attr('padding', '0 30px');
-      $('.paragraph--type--bb ilw-grid[width="full"]').attr('padding', '0 20px 30px').attr('innerwidth', '300px');
-    } else {
-      $('.paragraph--type--bb ilw-content[width="full"]').attr('padding', '0 40px');
-      $('.paragraph--type--bb ilw-grid[width="full"]').attr('padding', '0 30px 30px').attr('innerwidth', '460px');
-    }
+    const isMobile = window.matchMedia('(max-width: 599px)').matches;
+
+    document
+      .querySelectorAll('.paragraph--type--bb ilw-content[width="full"]')
+      .forEach(function (el) {
+        el.setAttribute('padding', isMobile ? '0 30px' : '0 40px');
+      });
+
+    document
+      .querySelectorAll('.paragraph--type--bb ilw-grid[width="full"]')
+      .forEach(function (el) {
+        el.setAttribute('padding', isMobile ? '0 20px 30px' : '0 30px 30px');
+        el.setAttribute('innerwidth', isMobile ? '300px' : '460px');
+      });
   }
 
-  // Run once on DOM ready
-  setFullWidthPadding();
+  Drupal.behaviors.paragraphBb = {
+    attach: function (context) {
+      const widthSelector = [
+        'ilw-columns .paragraph--type--bb ilw-content[width="page"]',
+        'ilw-columns .paragraph--type--bb ilw-content[width="full"]',
+        'ilw-columns .paragraph--type--bb ilw-grid[width="page"]',
+        'ilw-columns .paragraph--type--bb ilw-grid[width="full"]',
+        // fix for paragraphs in news content type
+        'article.news .paragraph--type--bb ilw-content[width="page"]',
+        'article.news .paragraph--type--bb ilw-grid[width="page"]',
+        // fix for paragraphs in spotlight content type
+        'article.spotlight .paragraph--type--bb ilw-content[width="page"]',
+        'article.spotlight .paragraph--type--bb ilw-grid[width="page"]'
+      ].join(', ');
+      once('paragraphBb', widthSelector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
 
-  // Run on resize
-  $(window).on('resize', setFullWidthPadding);
-});
+      // Apply responsive padding now; bind the resize listener only once.
+      setFullWidthPadding();
+      once('paragraphBbResize', 'html', context).forEach(function () {
+        window.addEventListener('resize', setFullWidthPadding);
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-calendar.js
+++ b/js/paragraph-calendar.js
@@ -1,3 +1,11 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--calendar ilw-content[width="auto"]').removeAttr('width');
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphCalendar = {
+    attach: function (context) {
+      const selector = 'ilw-columns .paragraph--type--calendar ilw-content[width="auto"]';
+
+      once('paragraphCalendar', selector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-card.js
+++ b/js/paragraph-card.js
@@ -1,5 +1,20 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--cards ilw-content[width="page"], ilw-columns .paragraph--type--cards ilw-grid[width="page"]').removeAttr('width');
-  $('article.news .paragraph--type--cards ilw-content[width="page"], article.news .paragraph--type--cards ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in news content type
-  $('article.spotlight .paragraph--type--cards ilw-content[width="page"], article.spotlight .paragraph--type--cards ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in spotlight content type
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphCard = {
+    attach: function (context) {
+      const selector = [
+        'ilw-columns .paragraph--type--cards ilw-content[width="page"]',
+        'ilw-columns .paragraph--type--cards ilw-grid[width="page"]',
+        // fix for paragraphs in news content type
+        'article.news .paragraph--type--cards ilw-content[width="page"]',
+        'article.news .paragraph--type--cards ilw-grid[width="page"]',
+        // fix for paragraphs in spotlight content type
+        'article.spotlight .paragraph--type--cards ilw-content[width="page"]',
+        'article.spotlight .paragraph--type--cards ilw-grid[width="page"]'
+      ].join(', ');
+
+      once('paragraphCard', selector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-contact.js
+++ b/js/paragraph-contact.js
@@ -1,19 +1,40 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--contact ilw-columns[width="auto"]').removeAttr('width');
-  $('.paragraph--type--contact ilw-columns[theme="gray"]').attr('padding', '30px 0');
-
-  // Store elements that originally have the reverse attribute
-  let $reverseEls = $('ilw-columns[reverse]').toArray();
-
-  $(window).on('resize load', function() {
-    if (window.matchMedia('(max-width: 599px)').matches) {
-      $reverseEls.forEach(function(el) {
-        el.removeAttribute('reverse');
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphContact = {
+    attach: function (context) {
+      once(
+        'paragraphContactWidth',
+        'ilw-columns .paragraph--type--contact ilw-columns[width="auto"]',
+        context
+      ).forEach(function (el) {
+        el.removeAttribute('width');
       });
-    } else {
-      $reverseEls.forEach(function(el) {
-        el.setAttribute('reverse', '');
+
+      once(
+        'paragraphContactGray',
+        '.paragraph--type--contact ilw-columns[theme="gray"]',
+        context
+      ).forEach(function (el) {
+        el.setAttribute('padding', '30px 0');
       });
+
+      // Capture the elements that originally have the reverse attribute, then
+      // toggle it based on viewport width (apply now and on resize).
+      const reverseEls = once('paragraphContactReverse', 'ilw-columns[reverse]', context);
+      if (reverseEls.length) {
+        const updateReverse = function () {
+          const isMobile = window.matchMedia('(max-width: 599px)').matches;
+          reverseEls.forEach(function (el) {
+            if (isMobile) {
+              el.removeAttribute('reverse');
+            } else {
+              el.setAttribute('reverse', '');
+            }
+          });
+        };
+
+        updateReverse();
+        window.addEventListener('resize', updateReverse);
+      }
     }
-  });
-});
+  };
+})(Drupal, once);

--- a/js/paragraph-content-slider.js
+++ b/js/paragraph-content-slider.js
@@ -1,3 +1,11 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--content-slider ilw-content[width="auto"]').removeAttr('width');
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphContentSlider = {
+    attach: function (context) {
+      const selector = 'ilw-columns .paragraph--type--content-slider ilw-content[width="auto"]';
+
+      once('paragraphContentSlider', selector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-cta-narrow.js
+++ b/js/paragraph-cta-narrow.js
@@ -1,3 +1,11 @@
-jQuery(function($) {
-  $('ilw-columns .cta-narrow-wrapper.fixed-width').removeClass('fixed-width');
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphCtaNarrow = {
+    attach: function (context) {
+      const selector = 'ilw-columns .cta-narrow-wrapper.fixed-width';
+
+      once('paragraphCtaNarrow', selector, context).forEach(function (el) {
+        el.classList.remove('fixed-width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-feature-group.js
+++ b/js/paragraph-feature-group.js
@@ -1,5 +1,17 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--feature-grouped ilw-columns[width="auto"]').removeAttr('width');
-  $('article.news .paragraph--type--feature-grouped ilw-columns[width="auto"]').removeAttr('width');//fix for paragraphs in news content type
-  $('article.spotlight .paragraph--type--feature-grouped ilw-columns[width="auto"]').removeAttr('width');//fix for paragraphs in spotlight content type
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphFeatureGroup = {
+    attach: function (context) {
+      const selector = [
+        'ilw-columns .paragraph--type--feature-grouped ilw-columns[width="auto"]',
+        // fix for paragraphs in news content type
+        'article.news .paragraph--type--feature-grouped ilw-columns[width="auto"]',
+        // fix for paragraphs in spotlight content type
+        'article.spotlight .paragraph--type--feature-grouped ilw-columns[width="auto"]'
+      ].join(', ');
+
+      once('paragraphFeatureGroup', selector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-icon-row.js
+++ b/js/paragraph-icon-row.js
@@ -1,5 +1,20 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--icon-row ilw-content[width="auto"], ilw-columns .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');
-  $('article.news .paragraph--type--icon-row ilw-content[width="auto"], article.news .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in news content type
-  $('article.spotlight .paragraph--type--icon-row ilw-content[width="auto"], article.spotlight .paragraph--type--icon-row ilw-grid[width="page"]').removeAttr('width');//fix for paragraphs in spotlight content type
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphIconRow = {
+    attach: function (context) {
+      const selector = [
+        'ilw-columns .paragraph--type--icon-row ilw-content[width="auto"]',
+        'ilw-columns .paragraph--type--icon-row ilw-grid[width="page"]',
+        // fix for paragraphs in news content type
+        'article.news .paragraph--type--icon-row ilw-content[width="auto"]',
+        'article.news .paragraph--type--icon-row ilw-grid[width="page"]',
+        // fix for paragraphs in spotlight content type
+        'article.spotlight .paragraph--type--icon-row ilw-content[width="auto"]',
+        'article.spotlight .paragraph--type--icon-row ilw-grid[width="page"]'
+      ].join(', ');
+
+      once('paragraphIconRow', selector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-image-gallery.js
+++ b/js/paragraph-image-gallery.js
@@ -1,5 +1,17 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--image-gallery ilw-content[width="auto"]').removeAttr('width');
-  $('ilw-columns .paragraph--type--image-gallery ilw-grid[width="auto"]').removeAttr('width');
-  $('article.news .paragraph--type--image-gallery ilw-grid[width="auto"], article.news .paragraph--type--image-gallery ilw-content[width="auto"]').removeAttr('width');//fix for paragraphs in news content type
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphImageGallery = {
+    attach: function (context) {
+      const selector = [
+        'ilw-columns .paragraph--type--image-gallery ilw-content[width="auto"]',
+        'ilw-columns .paragraph--type--image-gallery ilw-grid[width="auto"]',
+        // fix for paragraphs in news content type
+        'article.news .paragraph--type--image-gallery ilw-grid[width="auto"]',
+        'article.news .paragraph--type--image-gallery ilw-content[width="auto"]'
+      ].join(', ');
+
+      once('paragraphImageGallery', selector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-list-content.js
+++ b/js/paragraph-list-content.js
@@ -1,8 +1,46 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--list ilw-content[width="auto"][theme="gray"]').removeAttr('width').attr('padding', '15px 20px 30px 20px');
-  $('ilw-columns .paragraph--type--list ilw-content[width="auto"]:not([theme="gray"])').removeAttr('width').attr('padding', '30px 0');
-  $('ilw-columns .paragraph--type--list ilw-columns ilw-content[theme="gray"]').attr('padding', '20px');
-  $('ilw-columns .paragraph--type--list ilw-columns[width="page"]').removeAttr('width');
-  $('article.news .paragraph--type--list ilw-content[width="auto"], article.news .paragraph--type--list ilw-columns[width="page"]').removeAttr('width');//fix for paragraphs in news content type
-  $('article.spotlight .paragraph--type--list ilw-content[width="auto"], article.spotlight .paragraph--type--list ilw-columns[width="page"]').removeAttr('width');//fix for paragraphs in spotlight content type
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphListContent = {
+    attach: function (context) {
+      // Gray theme content: remove width, add larger padding.
+      once(
+        'paragraphListContentGray',
+        'ilw-columns .paragraph--type--list ilw-content[width="auto"][theme="gray"]',
+        context
+      ).forEach(function (el) {
+        el.removeAttribute('width');
+        el.setAttribute('padding', '15px 20px 30px 20px');
+      });
+
+      // Non-gray content: remove width, add vertical padding.
+      once(
+        'paragraphListContentPlain',
+        'ilw-columns .paragraph--type--list ilw-content[width="auto"]:not([theme="gray"])',
+        context
+      ).forEach(function (el) {
+        el.removeAttribute('width');
+        el.setAttribute('padding', '30px 0');
+      });
+
+      // Nested gray columns content: padding only.
+      once(
+        'paragraphListContentNested',
+        'ilw-columns .paragraph--type--list ilw-columns ilw-content[theme="gray"]',
+        context
+      ).forEach(function (el) {
+        el.setAttribute('padding', '20px');
+      });
+
+      // Remaining width attributes to remove (incl. news/spotlight fixes).
+      const widthSelector = [
+        'ilw-columns .paragraph--type--list ilw-columns[width="page"]',
+        'article.news .paragraph--type--list ilw-content[width="auto"]',
+        'article.news .paragraph--type--list ilw-columns[width="page"]',
+        'article.spotlight .paragraph--type--list ilw-content[width="auto"]',
+        'article.spotlight .paragraph--type--list ilw-columns[width="page"]'
+      ].join(', ');
+      once('paragraphListContentWidth', widthSelector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-rt.js
+++ b/js/paragraph-rt.js
@@ -1,7 +1,25 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--rt ilw-content[width="auto"]:not([theme="gray"])').removeAttr('width');
-  $('ilw-columns .paragraph--type--rt ilw-content[width="auto"][theme="gray"]').removeAttr('width').attr('padding', '20px 20px 30px');
-  $('ilw-columns .paragraph--type--rt ilw-columns[width="auto"]').removeAttr('width');
-  $('article.news .paragraph--type--rt ilw-content[width="auto"]').removeAttr('width');//fix for paragraphs in news content type
-  $('article.spotlight .paragraph--type--rt ilw-content[width="auto"]').removeAttr('width');//fix for paragraphs in spotlight content type
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphRt = {
+    attach: function (context) {
+      // Gray theme content keeps its width removed but gains padding.
+      const graySelector = 'ilw-columns .paragraph--type--rt ilw-content[width="auto"][theme="gray"]';
+      once('paragraphRtGray', graySelector, context).forEach(function (el) {
+        el.removeAttribute('width');
+        el.setAttribute('padding', '20px 20px 30px');
+      });
+
+      // Everything else simply has its width attribute removed.
+      const widthSelector = [
+        'ilw-columns .paragraph--type--rt ilw-content[width="auto"]:not([theme="gray"])',
+        'ilw-columns .paragraph--type--rt ilw-columns[width="auto"]',
+        // fix for paragraphs in news content type
+        'article.news .paragraph--type--rt ilw-content[width="auto"]',
+        // fix for paragraphs in spotlight content type
+        'article.spotlight .paragraph--type--rt ilw-content[width="auto"]'
+      ].join(', ');
+      once('paragraphRt', widthSelector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-vertical-tab.js
+++ b/js/paragraph-vertical-tab.js
@@ -1,7 +1,21 @@
-jQuery(function($) {
-  $('ilw-columns .paragraph--type--vertical-tab ilw-content[width="auto"]').removeAttr('width');
-  $('.paragraph--type--vertical-tab ilw-content[width="auto"]').removeAttr('width');
-  $('ilw-columns .paragraph--type--vertical-tab ilw-tabs[width="auto"]').removeAttr('width');
-  $('article.news .paragraph--type--vertical-tab ilw-content[width="auto"], article.news .paragraph--type--vertical-tab ilw-tabs[width="auto"]').removeAttr('width');//fix for paragraphs in news content type
-  $('article.spotlight .paragraph--type--vertical-tab ilw-content[width="auto"], article.spotlight .paragraph--type--vertical-tab ilw-tabs[width="auto"]').removeAttr('width');//fix for paragraphs in spotlight content type
-});
+(function (Drupal, once) {
+  Drupal.behaviors.paragraphVerticalTab = {
+    attach: function (context) {
+      const selector = [
+        'ilw-columns .paragraph--type--vertical-tab ilw-content[width="auto"]',
+        '.paragraph--type--vertical-tab ilw-content[width="auto"]',
+        'ilw-columns .paragraph--type--vertical-tab ilw-tabs[width="auto"]',
+        // fix for paragraphs in news content type
+        'article.news .paragraph--type--vertical-tab ilw-content[width="auto"]',
+        'article.news .paragraph--type--vertical-tab ilw-tabs[width="auto"]',
+        // fix for paragraphs in spotlight content type
+        'article.spotlight .paragraph--type--vertical-tab ilw-content[width="auto"]',
+        'article.spotlight .paragraph--type--vertical-tab ilw-tabs[width="auto"]'
+      ].join(', ');
+
+      once('paragraphVerticalTab', selector, context).forEach(function (el) {
+        el.removeAttribute('width');
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/paragraph-whitespace.js
+++ b/js/paragraph-whitespace.js
@@ -1,14 +1,23 @@
-jQuery(function ($) {
-  // find each div with the white background class
-  ($("div:not(.paragraph--type--feature-split, .paragraph--type--feature-video)").find(".background--color--white")).each(function () {
-      /*
-         Check to see if the next direct div has the same white background class.
-         If so, then reduce the bottom padding on the current div and reduce
-         the top padding on the next div with a white background.
-      */
-      if($(this).next("div").not(".paragraph--type--feature-split, .paragraph--type--feature-video").hasClass("background--color--white")){
-        $(this).addClass('reduce-padding--bottom');
-        $(this).next("div").addClass('reduce-padding--top');
-      }
-    });
-});
+(function (Drupal, once) {
+  // When two adjacent white-background blocks stack, trim the doubled padding
+  // between them by reducing the bottom padding of the first and the top
+  // padding of the second.
+  Drupal.behaviors.paragraphWhitespace = {
+    attach: function (context) {
+      once('paragraphWhitespace', '.background--color--white', context).forEach(function (el) {
+        const next = el.nextElementSibling;
+
+        if (
+          next &&
+          next.tagName === 'DIV' &&
+          !next.classList.contains('paragraph--type--feature-split') &&
+          !next.classList.contains('paragraph--type--feature-video') &&
+          next.classList.contains('background--color--white')
+        ) {
+          el.classList.add('reduce-padding--bottom');
+          next.classList.add('reduce-padding--top');
+        }
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/table-mobile.js
+++ b/js/table-mobile.js
@@ -1,60 +1,53 @@
 // Add a responsive wrapper to normal editor-authored tables. Tables using the
 // stacked style or an existing custom wrapper div are left alone.
-(function (Drupal, $) {
+(function (Drupal, once) {
   Drupal.behaviors.tableResponsiveWrapper = {
     attach: function (context) {
-      $(context)
-        .find('table')
-        .add($(context).filter('table'))
-        .each(function () {
-          const $table = $(this);
-          const $parent = $table.parent();
-
-          if ($table.hasClass('table-stack')) {
-            return;
-          }
-
-          if ($parent.hasClass('table-responsive-wrapper')) {
-            return;
-          }
-
-          if ($parent.is('div[class]')) {
-            return;
-          }
-
-          $table
-            .removeClass('table-responsive-wrapper')
-            .wrap('<div class="table-responsive-wrapper"></div>');
-        });
-    }
-  };
-})(Drupal, jQuery);
-
-// Automatically apply data-label attributes to .table-stack tables
-// so the CSS ::before pseudo-element can display header labels in stacked mobile view.
-(function (Drupal, $) {
-  Drupal.behaviors.tableStackLabels = {
-    attach: function (context) {
-      $(context).find('.table-stack').each(function () {
-        const $table = $(this);
-        const headers = [];
-
-        $table.find('thead th').each(function () {
-          headers.push($(this).text().trim());
-        });
-
-        if (!headers.length) {
+      once('tableResponsiveWrapper', 'table', context).forEach(function (table) {
+        if (table.classList.contains('table-stack')) {
           return;
         }
 
-        $table.find('tbody tr').each(function () {
-          $(this).find('td').each(function (index) {
-            if (headers[index]) {
-              $(this).attr('data-label', headers[index]);
-            }
-          });
-        });
+        const parent = table.parentElement;
+        if (parent && parent.tagName === 'DIV' && parent.hasAttribute('class')) {
+          return;
+        }
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'table-responsive-wrapper';
+        table.replaceWith(wrapper);
+        wrapper.appendChild(table);
       });
     }
   };
-})(Drupal, jQuery);
+})(Drupal, once);
+
+// Automatically apply data-label attributes to .table-stack tables
+// so the CSS ::before pseudo-element can display header labels in stacked mobile view.
+(function (Drupal, once) {
+  Drupal.behaviors.tableStackLabels = {
+    attach: function (context) {
+      once('tableStackLabels', '.table-stack', context).forEach(function (table) {
+        const headerCells = table.querySelectorAll('thead th');
+        if (!headerCells.length) {
+          return;
+        }
+
+        const headers = [];
+        for (let i = 0; i < headerCells.length; i++) {
+          headers.push(headerCells[i].textContent.trim());
+        }
+
+        const rows = table.querySelectorAll('tbody tr');
+        for (let r = 0; r < rows.length; r++) {
+          const cells = rows[r].cells;
+          for (let c = 0; c < cells.length && c < headers.length; c++) {
+            if (headers[c]) {
+              cells[c].setAttribute('data-label', headers[c]);
+            }
+          }
+        }
+      });
+    }
+  };
+})(Drupal, once);

--- a/js/table-mobile.js
+++ b/js/table-mobile.js
@@ -1,0 +1,51 @@
+// Move the responsive class from editor-authored tables to a wrapper so overflow
+// belongs to a real container, including inside sidebar column layouts.
+(function (Drupal, $) {
+  Drupal.behaviors.tableResponsiveWrapper = {
+    attach: function (context) {
+      $(context)
+        .find('table.table-responsive-wrapper')
+        .add($(context).filter('table.table-responsive-wrapper'))
+        .each(function () {
+          const $table = $(this);
+
+          if ($table.parent().hasClass('table-responsive-wrapper')) {
+            return;
+          }
+
+          $table
+            .removeClass('table-responsive-wrapper')
+            .wrap('<div class="table-responsive-wrapper"></div>');
+        });
+    }
+  };
+})(Drupal, jQuery);
+
+// Automatically apply data-label attributes to .table-stack tables
+// so the CSS ::before pseudo-element can display header labels in stacked mobile view.
+(function (Drupal, $) {
+  Drupal.behaviors.tableStackLabels = {
+    attach: function (context) {
+      $(context).find('.table-stack').each(function () {
+        const $table = $(this);
+        const headers = [];
+
+        $table.find('thead th').each(function () {
+          headers.push($(this).text().trim());
+        });
+
+        if (!headers.length) {
+          return;
+        }
+
+        $table.find('tbody tr').each(function () {
+          $(this).find('td').each(function (index) {
+            if (headers[index]) {
+              $(this).attr('data-label', headers[index]);
+            }
+          });
+        });
+      });
+    }
+  };
+})(Drupal, jQuery);

--- a/js/table-mobile.js
+++ b/js/table-mobile.js
@@ -1,15 +1,24 @@
-// Move the responsive class from editor-authored tables to a wrapper so overflow
-// belongs to a real container, including inside sidebar column layouts.
+// Add a responsive wrapper to normal editor-authored tables. Tables using the
+// stacked style or an existing custom wrapper div are left alone.
 (function (Drupal, $) {
   Drupal.behaviors.tableResponsiveWrapper = {
     attach: function (context) {
       $(context)
-        .find('table.table-responsive-wrapper')
-        .add($(context).filter('table.table-responsive-wrapper'))
+        .find('table')
+        .add($(context).filter('table'))
         .each(function () {
           const $table = $(this);
+          const $parent = $table.parent();
 
-          if ($table.parent().hasClass('table-responsive-wrapper')) {
+          if ($table.hasClass('table-stack')) {
+            return;
+          }
+
+          if ($parent.hasClass('table-responsive-wrapper')) {
+            return;
+          }
+
+          if ($parent.is('div[class]')) {
             return;
           }
 


### PR DESCRIPTION
## 📝 Description
Fixes #1317 

Converted all theme JavaScript to vanilla JS using `Drupal.behaviors` + `once()`, and removed jQuery as a dependency.

## Converted (14 files -> `Drupal.behaviors.<name>` + `once(id, selector, context)`, vanilla DOM)
- **Simple attr/class:** `paragraph-icon-row`, `-feature-group`, `-rt`, `-content-slider`, `-card`, `-image-gallery`, `-calendar`, `-list-content`, `-cta-narrow`, `-vertical-tab` (`removeAttr/attr/removeClass` -> `removeAttribute`/`setAttribute`/`classList`).
- **With logic:** `paragraph-bb` (matchMedia padding + resize bound once), `paragraph-contact` (captures `[reverse]` els, toggles on resize), `paragraph-whitespace` (sibling traversal via `nextElementSibling`/`classList`), `google-cse` (script injection guarded by `once`, reads `drupalSettings`).
- `table-mobile.js` was already converted on the base branch.

## `illinois_framework_theme.libraries.yml`
- Removed **all** `core/jquery` dependencies (6 libraries).
- Added explicit `core/drupal` + `core/once` to every library running a converted behavior.
- Kept `core/drupalSettings` for `google-cse` and `skipto-campus`.

## Verification
- `node --check` passes on all 15 JS files.
- `libraries.yml` validates as YAML.
- Theme-wide sweep confirms **zero** remaining `jQuery` / `$(` / `core/jquery`.

## Notes
- `paragraph-whitespace.js` is an orphan (not referenced in `libraries.yml`); converted for completeness but not wired up - a pre-existing condition.
- External libs (Toolkit web-components, SkipTo, ils-*) are vanilla and don't require jQuery.
- Changes take effect after `drush cr`.

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
