### PR TITLE
rich text paragraph remove width auto in ilw content and re add javascript

### DIFF
--- a/css/layout/layout.css
+++ b/css/layout/layout.css
@@ -8,12 +8,14 @@
 }
 
 /* Remove the fixed width padding when:
-**   1) it is inside a two-column layout. The page-content-wrapper class is applied in the page.html.twig template
-**   2) it is inside the ilw-content element with the width set to page
-**   3) it is nested inside another fixed-width element. This allows for nested fixed-width elements without the padding stacking up.
+**   - it is inside a two-column layout. The page-content-wrapper class is applied in the page.html.twig template
+**   - it is inside the ilw-content element with the width set to page
+**   - it is inside the ilw-columns element with the width set to page
+**   - it is nested inside another fixed-width element. This allows for nested fixed-width elements without the padding stacking up.
 */
 .page-content-wrapper .fixed-width,
 ilw-content[width="page"] .fixed-width,
+ilw-columns[width="page"] .fixed-width,
 .fixed-width :where(.fixed-width) {
   padding: 0;
 }

--- a/js/paragraph-rt.js
+++ b/js/paragraph-rt.js
@@ -1,3 +1,4 @@
 jQuery(function($) {
   $('ilw-columns .paragraph--type--rt ilw-content[theme="gray"]').attr('padding', '20px 20px 30px');
+  $('ilw-columns .paragraph--type--rt ilw-columns[width="auto"]').removeAttr('width');
 });

--- a/templates/paragraphs/paragraph--rt.html.twig
+++ b/templates/paragraphs/paragraph--rt.html.twig
@@ -82,11 +82,13 @@
           </div>
         </ilw-content>
       {% else %}
-        <ilw-content width="auto">
-          {% if content.field_rt_title['#items'] %}
-            <h2>{{ content.field_rt_title }}</h2>
-          {% endif %}
-        </ilw-content>
+    <ilw-content theme="{{ theme }}" padding="{{ padding }}">
+      <div class="fixed-width">
+        {% if content.field_rt_title['#items'] %}
+          <h2>{{ content.field_rt_title }}</h2>
+        {% endif %}
+      </div>
+    </ilw-content>
         <ilw-columns theme="{{ theme }}" width="auto" gap="40px" padding="{{ padding }}">
           {% for item in content.field_rt_column['#items'] %}
             {% set title = content.field_rt_column[loop.index0]['#paragraph'].field_rt_content_title.value %}


### PR DESCRIPTION
## 📝 Description
*removed width=auto on ilw-content and added javascript that was accidentally removed*

Fixes #1323
---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
