### PR TITLE
responsive-wrapper added by default to tables and clean up of table.js

### DIFF
--- a/js/table-mobile.js
+++ b/js/table-mobile.js
@@ -1,23 +1,42 @@
 // Add a responsive wrapper to normal editor-authored tables. Tables using the
-// stacked style or an existing custom wrapper div are left alone.
+// stacked style or an existing custom wrapper div are left alone. A fixed-width
+// parent is a layout container, so tables inside it still get an inner wrapper.
 (function (Drupal, once) {
+  const responsiveWrapperClass = 'table-responsive-wrapper';
+  const stackedTableClass = 'table-stack';
+  const fixedWidthClass = 'fixed-width';
+  const responsiveTableSelector = `table:not(.${stackedTableClass})`;
+
   Drupal.behaviors.tableResponsiveWrapper = {
     attach: function (context) {
-      once('tableResponsiveWrapper', 'table', context).forEach(function (table) {
-        if (table.classList.contains('table-stack')) {
-          return;
-        }
+      once('tableResponsiveWrapper', responsiveTableSelector, context).forEach(
+        function (table) {
+          table.classList.remove(responsiveWrapperClass);
 
-        const parent = table.parentElement;
-        if (parent && parent.tagName === 'DIV' && parent.hasAttribute('class')) {
-          return;
-        }
+          if (table.classList.contains(stackedTableClass)) {
+            return;
+          }
 
-        const wrapper = document.createElement('div');
-        wrapper.className = 'table-responsive-wrapper';
-        table.replaceWith(wrapper);
-        wrapper.appendChild(table);
-      });
+          const parent = table.parentElement;
+          if (parent && parent.classList.contains(responsiveWrapperClass)) {
+            return;
+          }
+
+          if (
+            parent &&
+            parent.tagName === 'DIV' &&
+            parent.hasAttribute('class') &&
+            !parent.classList.contains(fixedWidthClass)
+          ) {
+            return;
+          }
+
+          const wrapper = document.createElement('div');
+          wrapper.className = responsiveWrapperClass;
+          table.replaceWith(wrapper);
+          wrapper.appendChild(table);
+        }
+      );
     }
   };
 })(Drupal, once);
@@ -28,6 +47,8 @@
   Drupal.behaviors.tableStackLabels = {
     attach: function (context) {
       once('tableStackLabels', '.table-stack', context).forEach(function (table) {
+        table.classList.remove('table-responsive-wrapper');
+
         const headerCells = table.querySelectorAll('thead th');
         if (!headerCells.length) {
           return;


### PR DESCRIPTION
## 📝 Description
*added more logic to the js for what wrapper divs to ignore and fixed the data attributes getting applied*

Fixes #1324 
---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
