### PR TITLE
using the image field in twig template

### DIFF
--- a/templates/paragraphs/paragraph--feature-boxed.html.twig
+++ b/templates/paragraphs/paragraph--feature-boxed.html.twig
@@ -78,7 +78,7 @@
     {% block content %}
       <div class="feature-box">
         <div class="ilw-image-cover">
-          <img src="{{ base_path_http ~ file_url(content.field_feature_boxed_img['#items'].entity.uri.value) }}" alt="{{ content.field_feature_boxed_img['#items'].entity.alt }}" />
+          {{ content.field_feature_boxed_img }}
         </div>
         <ilw-card theme="{{ theme }}" class="{{ align }}">
           {% if content.field_feature_boxed_subtitle['#items'] %}


### PR DESCRIPTION
## 📝 Description
*updated the twig template to use the image field*

Fixes #1319

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
