### PR TITLE
adding compact boolean field to paragraph accordion

### DIFF
--- a/css/paragraphs/paragraphs.accordion.css
+++ b/css/paragraphs/paragraphs.accordion.css
@@ -10,6 +10,21 @@ article.news, article.spotlight {
   }
 }
 
+/* fixes the bottom border on compact accordion extending the full width of page */
+.paragraph--type--accordion ilw-accordion[compact][width="page"] {
+  border-bottom: 0;
+  position: relative;
+}
+
+.paragraph--type--accordion ilw-accordion[compact][width="page"]::after {
+  border-bottom: 1px solid var(--il-storm-lighter-3, #C6C7C7);
+  bottom: 0;
+  content: "";
+  left: var(--ilw-margin--side, max(1.875rem, calc(50cqw - 35.625rem)));
+  position: absolute;
+  right: var(--ilw-margin--side, max(1.875rem, calc(50cqw - 35.625rem)));
+}
+
 .paragraph--type--accordion {
   margin-bottom: 3rem;
 }

--- a/templates/paragraphs/paragraph--accordion.html.twig
+++ b/templates/paragraphs/paragraph--accordion.html.twig
@@ -50,11 +50,11 @@
   {# Paragraph ID used for anchor linking #}
   <div {{ attributes.setAttribute('id', 'paragraph--' ~ paragraph.id() ) }} {{ attributes.addClass(classes) }}>
     {% block content %}
-      <ilw-accordion width="page">
+      <ilw-accordion width="page"{% if paragraph.field_accordion_compact.value %} compact="true"{% endif %}>
         {% if content.field_accordion_title['#items'] %}
           <h2>{{ content.field_accordion_title }}</h2>
         {% endif %}
-        {{ content|without('field_accordion_title') }}
+        {{ content|without('field_accordion_title', 'field_accordion_compact') }}
       </ilw-accordion>
     {% endblock %}
   </div>


### PR DESCRIPTION
## 📝 Description
*adding compact field to paragraph accordion twig template and css to fix bottom border*

Fixes #1315

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
