### PR TITLE
Release workflow action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -37,6 +37,18 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
+      - name: Ensure tag does not already exist
+        run: |
+          # Fail fast (before the AI call and any commit) if the release tag
+          # already exists locally or on the remote. The workflow never uses
+          # --force, so a pre-existing tag would otherwise fail later with a
+          # raw git error; this gives a clear message and avoids wasted work.
+          VERSION="${{ github.event.inputs.version }}"
+          if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "::error::Tag ${VERSION} already exists. Choose a new version or delete the existing tag."
+            exit 1
+          fi
+
       - name: Add packaging metadata to info.yml
         run: |
           # Mirrors the Drupal.org packaging script, which appends a

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,6 +1,7 @@
 # .github/workflows/create-release.yml
 # This workflow is triggered manually to create a new release.
-# It updates the version, commits, tags, and creates a GitHub Release.
+# It updates the version, tags the commit, and opens a DRAFT GitHub Release
+# with auto-generated notes so you can add custom notes before publishing.
 
 name: Create New Release
 
@@ -11,6 +12,11 @@ on:
         description: 'The new version number (e.g., 1.2.3)'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run: build and print the info.yml, but do NOT commit, tag, or release.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   create-release:
@@ -21,21 +27,167 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Full history + tags are needed to diff against the previous
+          # release when drafting release notes.
+          fetch-depth: 0
 
       - name: Configure Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Update version in info.yml
+      - name: Add packaging metadata to info.yml
         run: |
-          # The version is taken directly from the manual input.
-          VERSION=${{ github.event.inputs.version }}
-          # Use sed to find the line starting with "version:" and replace it.
-          # The single quotes are important for Drupal's YAML parser.
-          sed -i "s/^version: .*/version: '$VERSION'/" illinois_framework_theme.info.yml
+          # Mirrors the Drupal.org packaging script, which appends a
+          # version/project/datestamp block to each .info.yml at build time.
+          VERSION="${{ github.event.inputs.version }}"
+          PROJECT="illinois_framework_theme"
+          INFO_FILE="illinois_framework_theme.info.yml"
+          BUILD_DATE="$(date -u +%Y-%m-%d)"
+          DATESTAMP="$(date -u +%s)"
+
+          # Strip any existing packaging metadata so re-runs stay idempotent
+          # (removes the comment line plus the three generated keys).
+          sed -i \
+            -e '/^# Information added by .* packaging script on /d' \
+            -e '/^version: /d' \
+            -e '/^project: /d' \
+            -e '/^datestamp: /d' \
+            "$INFO_FILE"
+
+          # Drop any trailing blank lines left behind before appending.
+          awk 'NF{last=NR} {line[NR]=$0} END{for(i=1;i<=last;i++) print line[i]}' \
+            "$INFO_FILE" > "$INFO_FILE.tmp" && mv "$INFO_FILE.tmp" "$INFO_FILE"
+
+          # Append a fresh metadata block. Single quotes matter for Drupal's
+          # YAML parser (keeps version strings like '5.0' from becoming floats).
+          # Built with printf (not a heredoc) so the block stays indented inside
+          # this YAML step while still writing column-0 lines to the info file.
+          {
+            printf '\n'
+            printf '# Information added by web-illinois packaging script on %s\n' "$BUILD_DATE"
+            printf "version: '%s'\n" "$VERSION"
+            printf "project: '%s'\n" "$PROJECT"
+            printf 'datestamp: %s\n' "$DATESTAMP"
+          } >> "$INFO_FILE"
+
+          echo "----- Generated $INFO_FILE -----"
+          cat "$INFO_FILE"
+
+      - name: Determine previous release tag
+        id: prevtag
+        run: |
+          # The release tag isn't created yet, so the newest existing tag is
+          # the previous release. Empty on the very first release.
+          PREV_TAG="$(git tag --sort=-creatordate | head -n1)"
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${PREV_TAG:-<none>}"
+
+      - name: Collect changes since last release
+        run: |
+          if [ -n "${{ steps.prevtag.outputs.prev_tag }}" ]; then
+            RANGE="${{ steps.prevtag.outputs.prev_tag }}..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+          # Subjects + bodies give the AI enough to spot #issue / #PR references.
+          LOG="$(git log $RANGE --no-merges --pretty=format:'- %s%n%b' | head -c 12000)"
+          {
+            echo "COMMIT_LOG<<COMMIT_LOG_EOF"
+            echo "$LOG"
+            echo "COMMIT_LOG_EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Draft "Release Notes" section with AI (Azure OpenAI v1)
+        env:
+          # Secret: the Azure OpenAI / Foundry API key (Settings > Secrets and variables > Actions).
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          # Non-secret Actions variables (Settings > Secrets and variables > Actions > Variables):
+          #   AZURE_OPENAI_BASE_URL  the v1 API base, e.g.
+          #                          https://uiuc-las-ai-agent.openai.azure.com/openai/v1
+          #   AZURE_OPENAI_MODEL     the model deployment name, e.g. gpt-5.6-luna
+          AZURE_OPENAI_BASE_URL: ${{ vars.AZURE_OPENAI_BASE_URL }}
+          AZURE_OPENAI_MODEL: ${{ vars.AZURE_OPENAI_MODEL }}
+          # Passed via env (not inline ${{ }}) to avoid shell script injection.
+          VERSION: ${{ github.event.inputs.version }}
+          PREV_TAG: ${{ steps.prevtag.outputs.prev_tag }}
+          # COMMIT_LOG is exported by the previous step via $GITHUB_ENV.
+        run: |
+          set -euo pipefail
+
+          if [ -z "${AZURE_OPENAI_API_KEY:-}" ] || [ -z "${AZURE_OPENAI_BASE_URL:-}" ] || [ -z "${AZURE_OPENAI_MODEL:-}" ]; then
+            echo "::error::Missing Azure OpenAI config. Set the AZURE_OPENAI_API_KEY secret and the AZURE_OPENAI_BASE_URL / AZURE_OPENAI_MODEL variables."
+            exit 1
+          fi
+
+          # System prompt kept apostrophe-free so single-quoted lines stay simple.
+          SYSTEM_PROMPT="$(printf '%s\n' \
+            'You write release notes for the Illinois Framework Drupal theme.' \
+            'Output ONLY Markdown for a single section and nothing else.' \
+            'Start with the level-2 heading exactly: ## Release Notes' \
+            'Then include a "### New Features" list and/or a "### Bug Fixes" list.' \
+            'Omit a subsection that would be empty.' \
+            'Each bullet is a concise, user-facing summary of one change.' \
+            'When a change references an issue or PR number like #123, append it as (#123) so GitHub auto-links it. Never invent numbers.' \
+            'Ignore administrative commits such as version bumps, merges, CI changes, dependency lockfiles, and formatting-only changes.' \
+            'Do not add a pull-request changelog section; it is appended automatically later.' \
+            'If there are no user-facing changes, output the heading ## Release Notes followed by: _No user-facing changes in this release._')"
+
+          USER_PROMPT="$(printf 'Version being released: %s\nPrevious release: %s\n\nCommit log since the previous release:\n%s\n' \
+            "$VERSION" "${PREV_TAG:-none}" "${COMMIT_LOG:-}")"
+
+          # Build the request body with jq so all content is safely JSON-escaped.
+          # v1 API: the model deployment name goes in the body, not the URL.
+          REQUEST="$(jq -n \
+            --arg model "$AZURE_OPENAI_MODEL" \
+            --arg sys "$SYSTEM_PROMPT" \
+            --arg usr "$USER_PROMPT" \
+            '{model: $model, messages: [{role: "system", content: $sys}, {role: "user", content: $usr}], max_tokens: 800, temperature: 0.3}')"
+
+          # v1 GA API: POST to <base>/chat/completions, no api-version query param.
+          URL="${AZURE_OPENAI_BASE_URL%/}/chat/completions"
+
+          # --fail-with-body: on HTTP >=400, print the error body and fail the step.
+          set +e
+          RESP="$(curl -sS --fail-with-body -X POST "$URL" \
+            -H 'Content-Type: application/json' \
+            -H "api-key: ${AZURE_OPENAI_API_KEY}" \
+            -d "$REQUEST")"
+          CURL_EXIT=$?
+          set -e
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            echo "::error::Azure OpenAI request failed (curl exit $CURL_EXIT)."
+            echo "$RESP"
+            exit 1
+          fi
+
+          NOTES="$(printf '%s' "$RESP" | jq -r '.choices[0].message.content // empty')"
+          if [ -z "$NOTES" ]; then
+            NOTES="$(printf '%s\n\n%s\n' '## Release Notes' '_No release notes were generated. Please edit before publishing._')"
+          fi
+
+          printf '%s\n' "$NOTES" > RELEASE_BODY.md
+          echo "----- RELEASE_BODY.md -----"
+          cat RELEASE_BODY.md
+
+      - name: Dry run summary
+        if: github.event.inputs.dry_run == 'true'
+        run: |
+          echo "::notice::Dry run enabled — no commit, tag, or release was created."
+          {
+            echo "### Dry run: generated info.yml"
+            echo '```yaml'
+            cat illinois_framework_theme.info.yml
+            echo '```'
+            echo "### Dry run: AI-drafted release notes"
+            echo "_GitHub's \"What's Changed\" PR list is appended automatically at release time._"
+            echo ""
+            cat RELEASE_BODY.md
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit version update
+        if: github.event.inputs.dry_run != 'true'
         id: commit
         run: |
           git add illinois_framework_theme.info.yml
@@ -48,20 +200,29 @@ jobs:
             echo "changes=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create Git Tag and Push
-        if: steps.commit.outputs.changes == 'true'
+      - name: Create and push tag
+        if: github.event.inputs.dry_run != 'true' && steps.commit.outputs.changes == 'true'
         run: |
+          # Tag the local version-bump commit, then push ONLY the tag.
+          # The protected branch (e.g. 5.x) is never pushed to, so branch
+          # protection is satisfied. The metadata-bearing commit is reachable
+          # via the tag, which is what the Composer VCS install pulls from.
           git tag "${{ github.event.inputs.version }}"
-          git push origin HEAD --follow-tags
+          git push origin "refs/tags/${{ github.event.inputs.version }}"
 
-      - name: Create GitHub Release
-        if: steps.commit.outputs.changes == 'true'
-        uses: actions/create-release@v1
+      - name: Create GitHub Release (draft)
+        if: github.event.inputs.dry_run != 'true' && steps.commit.outputs.changes == 'true'
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: "${{ github.event.inputs.version }}"
-          release_name: "Release ${{ github.event.inputs.version }}"
+          name: "Release ${{ github.event.inputs.version }}"
+          # The AI-drafted "## Release Notes" section becomes the top of the
+          # body; generate_release_notes appends GitHub's "## What's Changed"
+          # PR list below it. Created as a draft so you can review and edit the
+          # AI output before publishing.
+          body_path: RELEASE_BODY.md
           generate_release_notes: true
-          draft: false
+          draft: true
           prerelease: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Full history + tags are needed to diff against the previous
           # release when drafting release notes.

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -139,11 +139,15 @@ jobs:
 
           # Build the request body with jq so all content is safely JSON-escaped.
           # v1 API: the model deployment name goes in the body, not the URL.
+          # GPT-5-series (reasoning) models require max_completion_tokens instead
+          # of max_tokens and only accept the default temperature, so temperature
+          # is omitted. The budget is generous because reasoning tokens count
+          # toward max_completion_tokens.
           REQUEST="$(jq -n \
             --arg model "$AZURE_OPENAI_MODEL" \
             --arg sys "$SYSTEM_PROMPT" \
             --arg usr "$USER_PROMPT" \
-            '{model: $model, messages: [{role: "system", content: $sys}, {role: "user", content: $usr}], max_tokens: 800, temperature: 0.3}')"
+            '{model: $model, messages: [{role: "system", content: $sys}, {role: "user", content: $usr}], max_completion_tokens: 2000}')"
 
           # v1 GA API: POST to <base>/chat/completions, no api-version query param.
           URL="${AZURE_OPENAI_BASE_URL%/}/chat/completions"

--- a/illinois_framework_theme.info.yml
+++ b/illinois_framework_theme.info.yml
@@ -3,7 +3,7 @@ type: theme
 description: 'The Illinois Framework Theme'
 core_version_requirement: ^9 || ^10
 base theme: stable9
-version: '5.0'
+version: '5.x-dev'
 
 libraries:
   - illinois_framework_theme/global


### PR DESCRIPTION
## 📝 Description
Fixes #1346

## Automate versioning and AI-drafted release notes in the release workflow

### Summary
Overhauls the manual **Create New Release** workflow so cutting a release now (1) stamps Drupal.org-style version metadata into the theme's `.info.yml`, (2) works with branch protection on `5.x`, and (3) opens a **draft** GitHub Release with an AI-drafted "Release Notes" section plus GitHub's auto-generated "What's Changed" list. Also sets the dev branch version to `5.x-dev`.

### Motivation
- Since the theme isn't on Drupal.org, releases lacked the `version`/`project`/`datestamp` metadata that platform normally injects.
- Release notes were fully auto-generated; we want a curated "Release Notes" section (features + bug fixes with issue links) in a consistent format, editable before publishing.

### What changed
**illinois_framework_theme.info.yml**
- Dev version set to `version: '5.x-dev'` so the Appearance page clearly shows when the latest dev branch is running.

**`.github/workflows/create-release.yml`**
- **Packaging metadata:** appends a `# Information added by web-illinois packaging script…` block with `version` (from the input), `project`, and `datestamp`. Idempotent (strips any prior block first) and built with `printf` so the injected column-0 lines don't break the YAML step.
- **Branch-protection safe:** pushes **only the tag** (`refs/tags/<version>`), never the `5.x` branch. The version metadata lives in the tag (mirrors Drupal.org and works for Composer VCS installs).
- **Draft release via a maintained action:** replaced the deprecated `actions/create-release@v1` with `softprops/action-gh-release@v2`, created as a **draft** for review before publishing.
- **AI-drafted "Release Notes":** new step calls the University of Illinois Azure OpenAI **v1** endpoint (`/openai/v1/chat/completions`) via `curl` + `jq` to draft a `## Release Notes` section (New Features / Bug Fixes with `#issue` links). `generate_release_notes: true` appends the "What's Changed" PR list beneath it.
- **Supporting steps:** `fetch-depth: 0`, previous-tag detection, and commit-log collection since the last release.
- **Dry-run mode:** new `dry_run` input builds and prints the `info.yml` and drafted notes to the run Summary without committing, tagging, or releasing.
- **Fixes/upkeep:** use `max_completion_tokens` (GPT-5-series requirement) instead of `max_tokens`, drop unsupported `temperature`; bump `actions/checkout` to `@v5` (Node 24).

### Required repo/org configuration
- **Secret:** `AZURE_OPENAI_API_KEY`
- **Variables:** `AZURE_OPENAI_BASE_URL` (e.g. `https://uiuc-las-ai-agent.openai.azure.com/openai/v1`) and `AZURE_OPENAI_MODEL` (deployment name, e.g. `gpt-5.6-luna`)

### Testing
- Ran the workflow with **Dry run** enabled: `info.yml` produced valid YAML with `version: '5.2.0'` in the packaging block, and the AI drafted a correctly formatted `## Release Notes` section (New Features + Bug Fixes with issue links). No tag/release created.
- Workflow YAML validated locally.

### Notes
- The version bump appears only in the release tag, so the `5.x` branch stays `5.x-dev` between releases (intended).
- Commit messages/PR titles drive the AI notes quality; thin messages can produce vague bullets — the draft is meant to be edited before publishing.
- `softprops/action-gh-release@v2` may emit a Node 20 deprecation notice on a real run (its step is skipped in dry run); non-blocking. Optionally pin to a commit SHA for supply-chain hardening.

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
