### PR TITLE
added homepage meta tag to frontpage via preprocess

### DIFF
--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -11,6 +11,7 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\paragraphs\ParagraphInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Returns the default Toolkit library URLs by parsing the libraries YAML file.
@@ -120,6 +121,20 @@ function illinois_framework_theme_preprocess(array &$variables) {
     }
       $variables['login_logout_url'] = $login_url;
   }
+  // Only on the Drupal front page.
+  if (\Drupal::service('path.matcher')->isFrontPage()) {
+    $variables['#attached']['html_head'][] = [
+      [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'category',
+          'content' => 'homepage',
+        ],
+      ],
+      'category_meta',
+    ];
+  }
+
 
   // TODO: Condense these into a single array like ['path_vars']['var'].
   $current_path = \Drupal::service('path.current')->getPath();

--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -11,7 +11,6 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\paragraphs\ParagraphInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Returns the default Toolkit library URLs by parsing the libraries YAML file.


### PR DESCRIPTION
## 📝 Description
*Provide a short summary that describes how the fix is implemented*

Fixes #1325 by injecting the <meta name=”category” content=”homepage”> via a preprocess function in theme.theme.

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
