### PR TITLE
fixing the node teaser suggestion order

### DIFF
--- a/illinois_framework_theme.theme
+++ b/illinois_framework_theme.theme
@@ -851,12 +851,32 @@ function illinois_framework_theme_preprocess_region(array &$variables): void {
   $variables['is_front'] = \Drupal::service('path.matcher')->isFrontPage();
 }
 
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for node.html.twig.
+ */
 function illinois_framework_theme_theme_suggestions_node_alter(array &$suggestions, array $variables) {
-  $node = $variables['elements']['#node'];
-  $view_mode = $variables['elements']['#view_mode'];
+  $node = $variables['elements']['#node'] ?? NULL;
+  $view_mode = $variables['elements']['#view_mode'] ?? NULL;
 
-  // If the view mode is a teaser, add node--teaser to the suggestions array
-  if ($view_mode === 'teaser') {
-    $suggestions[] = 'node__teaser';
+  if (!$node instanceof NodeInterface || $view_mode !== 'teaser') {
+    return;
   }
+
+  $teaser_suggestion = 'node__teaser';
+  $bundle_teaser_suggestion = 'node__' . $node->bundle() . '__teaser';
+
+  // Core puts the generic teaser suggestion before the bundle suggestion. That
+  // makes node--news.html.twig win over node--teaser.html.twig. Move the generic
+  // teaser immediately before the bundle-specific teaser so the lookup order is:
+  // node--news.html.twig, node--teaser.html.twig, node--news--teaser.html.twig.
+  $suggestions = array_values(array_diff($suggestions, [$teaser_suggestion]));
+  $bundle_teaser_index = array_search($bundle_teaser_suggestion, $suggestions, TRUE);
+
+  if ($bundle_teaser_index === FALSE) {
+    $suggestions[] = $teaser_suggestion;
+    $suggestions[] = $bundle_teaser_suggestion;
+    return;
+  }
+
+  array_splice($suggestions, $bundle_teaser_index, 0, [$teaser_suggestion]);
 }


### PR DESCRIPTION
fixing the node teaser suggestion order so that bundle specific template will be used

## 📝 Description
*added a bundle specific teaser and fixed the order of lookup for which template to use*

Fixes #1331 
---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
<img width="961" height="230" alt="Screenshot 2026-07-20 at 3 58 36 PM" src="https://github.com/user-attachments/assets/d39c688c-7d47-429d-b5ea-28aa74daa2cf" />
