### PR TITLE
removing padding on article.spotlight.full when there is a sidebar

### DIFF
--- a/css/node/node.spotlight-family.css
+++ b/css/node/node.spotlight-family.css
@@ -84,3 +84,9 @@ keeping it local to prevent compromising others use cases. */
   background-color:var(--il-cloud-1);
 }
 }
+
+/* This is overriding the padding on the spotlight when there is a sidebar */
+.page-content-wrapper article.spotlight.full {
+  padding: 0;
+  padding-inline: 0;
+}


### PR DESCRIPTION
## 📝 Description
*removed the spotlight padding when next to a sidebar*

Fixes #1343 
---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
