### PR TITLE
[#1346] Push release tag via release GitHub App

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,17 +25,34 @@ jobs:
       # Give the default GITHUB_TOKEN write permission to commit, tag, and release.
       contents: write
     steps:
+      - name: Generate a token from the release GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           # Full history + tags are needed to diff against the previous
           # release when drafting release notes.
           fetch-depth: 0
+          # Use the release GitHub App installation token so the tag push
+          # satisfies the "Restrict creations" tag ruleset. The App is on the
+          # ruleset bypass list; GITHUB_TOKEN / github-actions[bot] is not.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          # Author the version-bump commit as the release App's bot identity so
+          # history reflects the same App that pushes the tag.
+          BOT_NAME='${{ steps.app-token.outputs.app-slug }}[bot]'
+          BOT_ID="$(gh api "/users/${BOT_NAME}" --jq .id)"
+          git config --global user.name "${BOT_NAME}"
+          git config --global user.email "${BOT_ID}+${BOT_NAME}@users.noreply.github.com"
 
       - name: Ensure tag does not already exist
         run: |


### PR DESCRIPTION
The release workflow pushes the version tag from the checkout remote, which by default authenticates as github-actions[bot] using GITHUB_TOKEN. That identity is not on the tag ruleset bypass list, so 'Restrict creations' blocks the tag push (GH013).

Mint a short-lived installation token from a web-illinois GitHub App (actions/create-github-app-token) and use it for checkout, so the tag push and the version-bump commit are authored by the App, which is on each repo's tag ruleset bypass list. No long-lived token to rotate; only RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY are stored as secrets.

## 📝 Description
*Provide a short summary that describes how the fix is implemented*

Fixes #1346 

---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
