### PR TITLE
Upgrade create-github-app-token action to v3

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Generate a token from the release GitHub App
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Upgrade create-github-app-token action to v3 since the v2 was using deprecated node v20