### PR TITLE
add innerwidth attribute to card paragraph type to have a max of 3 across

### DIFF
--- a/templates/paragraphs/paragraph--cards.html.twig
+++ b/templates/paragraphs/paragraph--cards.html.twig
@@ -69,7 +69,7 @@
             <div class="field--name-field-cards__subtitle subtitle">{{ content.field_cards_subtitle }}</div>
             </ilw-content>
           {% endif %}
-      <ilw-grid width="page" theme="{{ content.field_cards_background['#items'].0.value }}" gap="20px">
+      <ilw-grid width="page" theme="{{ content.field_cards_background['#items'].0.value }}" innerwidth="300px" gap="20px">
 
           {% for item in content.field_cards_content['#items'] %}
             {% set image = content.field_cards_content[loop.index0]['#paragraph'].field_cards_content_image.entity.fileuri %}


### PR DESCRIPTION
## 📝 Description
*added innerwidth attribute to cards so that the row of cards is a max of 3*

Fixes #1330 
---

## ✅ Peer Review Checklist
*Reviewers: Please verify the following before approving.*

- **The pull request links to the issue** it is addressing in the comment and in the "Development" section of the PR
- There is a **short summary** that describes _how_ the fix is implemented
- **Verifying work**: Verify that the changes made are addressing the linked issue
- **Accessibility**: Changes that might impact accessibility are reviewed to work with keyboard navigation and screen readers
- **Responsive**: Layout is tested on desktop, tablet, and mobile screens
- **Config changes**: Any configuration updates are tested and verified using the Distribution Update import
- **Security:** Output is sanitized (using `t()`, Twig auto-escaping, etc.). No secrects included (API keys, etc.)
- **Cleanliness:** All debug code (`ksm()`, `dpm()`, `console.log`) has been removed.
- **Comments:** Complex logic is explained inline.
- **Documentation:** Any relevant documentation has been updated (this can be a separate issue if needed)

---

## 📸 Screenshots / Video (Optional)
*If this is a UI change, please attach a screenshot or a quick screen recording of the change in action.*
<img width="1445" height="971" alt="Screenshot 2026-07-30 at 9 53 36 AM" src="https://github.com/user-attachments/assets/2f6f2c73-7cb5-4a47-b9e1-a348305caea5" />
<img width="1321" height="972" alt="Screenshot 2026-07-30 at 9 53 54 AM" src="https://github.com/user-attachments/assets/a9adfbdb-cbcb-4f76-bcd2-3ab04a357599" />